### PR TITLE
Support for Link, Prefix and SRv6 SID NLRIs and their attributes

### DIFF
--- a/draft/Makefile
+++ b/draft/Makefile
@@ -56,13 +56,14 @@ endif
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*.yang
 	-rm -f ../bin/submodules/*\@$(shell date +%Y)*-*-*.yang
 
-$(next).xml: $(draft).xml ../src/yang/ietf-bgp-ls.yang ../src/yang/ietf-bgp-lsdb.yang ../src/yang/ietf-bgp-ls-topo-types.yang ../src/yang/ietf-bgp-ls-topo-attr.yang 
+$(next).xml: $(draft).xml ../src/yang/ietf-bgp-ls.yang ../src/yang/ietf-bgp-lsdb.yang ../src/yang/ietf-bgp-ls-topo-types.yang ../src/yang/ietf-bgp-ls-topo-attr.yang ../src/yang/ietf-bgp-ls-topo-ospf.yang 
 	-mkdir -p ../bin
 	-mkdir -p ../bin/submodules
 	sed -e"s/$(basename $<)-latest/$(basename $@)/" -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" $< > $@
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-ls.yang > ../bin/ietf-bgp-ls\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-ls-topo-types.yang > ../bin/ietf-bgp-ls-topo-types\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-ls-topo-attr.yang > ../bin/submodules/ietf-bgp-ls-topo-attr\@$(shell date +%Y-%m-%d).yang
+	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-ls-topo-ospf.yang > ../bin/submodules/ietf-bgp-ls-topo-ospf\@$(shell date +%Y-%m-%d).yang
 	sed -e"s/YYYY-MM-DD/$(shell date +%Y-%m-%d)/" ../src/yang/ietf-bgp-lsdb.yang > ../bin/ietf-bgp-lsdb\@$(shell date +%Y-%m-%d).yang
 
 	cd ../src; ./validate-and-gen-trees.sh; cd ..;

--- a/draft/draft-ietf-lsvr-bgp-ls-yang.xml
+++ b/draft/draft-ietf-lsvr-bgp-ls-yang.xml
@@ -335,7 +335,7 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp-lsdb@YYYY-MM-DD.yang)
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9552.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9815.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9911.xml"/>
-        <?rfc include='reference.I-D.ietf-idr-bgp-model.xml'?>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-idr-bgp-model.xml"/>
       </references>
  
       <references>

--- a/draft/draft-ietf-lsvr-bgp-ls-yang.xml
+++ b/draft/draft-ietf-lsvr-bgp-ls-yang.xml
@@ -214,6 +214,49 @@ INSERT_TEXT_FROM_FILE(../bin/ietf-bgp-lsdb@YYYY-MM-DD.yang)
         <!-- [CHECK] markers="true" means that the rendered file will have <CODE BEGINS> and <CODE ENDS> added -->
 	</figure>
       </section>
+      <section>
+	<name>BGP Link-State Topology Types YANG model</name>
+	<t>This module defines the identity and typedef declarations
+	shared by the BGP-LS topology attribute submodules.</t>
+	<figure>
+          <name>YANG Model for BGP-LS Topology Types</name>
+          <artwork><![CDATA[
+<CODE BEGINS> file "ietf-bgp-ls-topo-types@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/ietf-bgp-ls-topo-types@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+]]></artwork>
+	</figure>
+      </section>
+      <section>
+	<name>BGP Link-State Topology Attributes YANG model</name>
+	<t>This submodule defines the node, link, and prefix attribute
+	containers used in the BGP-LS Link-State Database.</t>
+	<figure>
+          <name>YANG Model for BGP-LS Topology Attributes</name>
+          <artwork><![CDATA[
+<CODE BEGINS> file "ietf-bgp-ls-topo-attr@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-ls-topo-attr@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+]]></artwork>
+	</figure>
+      </section>
+      <section>
+	<name>BGP Link-State Topology OSPF YANG model</name>
+	<t>This submodule defines the OSPFv2 and OSPFv3 node, link,
+	and prefix NLRI groupings used in the BGP-LS Link-State
+	Database.</t>
+	<figure>
+          <name>YANG Model for BGP-LS Topology OSPF</name>
+          <artwork><![CDATA[
+<CODE BEGINS> file "ietf-bgp-ls-topo-ospf@YYYY-MM-DD.yang"
+INSERT_TEXT_FROM_FILE(../bin/submodules/ietf-bgp-ls-topo-ospf@YYYY-MM-DD.yang)
+<CODE ENDS>
+
+]]></artwork>
+	</figure>
+      </section>
     </section>
     
     <section anchor="IANA">

--- a/src/yang/ietf-bgp-ls-topo-attr.yang
+++ b/src/yang/ietf-bgp-ls-topo-attr.yang
@@ -188,17 +188,6 @@ submodule ietf-bgp-ls-topo-attr {
     }
   }
 
-  grouping bgp-ls-topo-metric-attr {
-    description
-      "Grouping for the BGP-LS topology metric attribute";
-
-    leaf metric {
-      type uint32;
-      description
-        "Metric";
-    }
-  }
-
   grouping bgp-ls-topo-adj-sid-attr {
     description
       "Grouping for the BGP-LS topology adjacency SID attribute";
@@ -210,7 +199,7 @@ submodule ietf-bgp-ls-topo-attr {
     }
 
     leaf format {
-      type bgp-ls-topo-t:adj-sid-format;
+      type bgp-ls-topo-t:sid-format;
       description
         "Format of the SID";
     }
@@ -229,23 +218,6 @@ submodule ietf-bgp-ls-topo-attr {
       type uint8;
       description
         "Weight used for load balancing purposes";
-    }
-  }
-
-  grouping bgp-ls-topo-lan-adj-sid-attr {
-    description
-      "Grouping for the BGP-LS topology LAN adjacency SID
-       attribute";
-
-    uses bgp-ls-topo-adj-sid-attr;
-
-    leaf neighbor-id {
-      type union {
-        type inet:ipv4-address;
-        type ietf-isis-t:system-id;
-      }
-      description
-        "Neighbor ID";
     }
   }
 
@@ -268,7 +240,11 @@ submodule ietf-bgp-ls-topo-attr {
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP. TLV 1092";
 
-      uses bgp-ls-topo-metric-attr;
+      leaf metric {
+        type uint32;
+        description
+          "Traffic Engineering metric";
+      }
     }
 
     container unidirectional-link-delay {
@@ -613,7 +589,16 @@ submodule ietf-bgp-ls-topo-attr {
         description
           "List of LAN adjacency SID";
 
-        uses bgp-ls-topo-lan-adj-sid-attr;
+        uses bgp-ls-topo-adj-sid-attr;
+
+        leaf neighbor-id {
+          type union {
+            type inet:ipv4-address;
+            type ietf-isis-t:system-id;
+          }
+          description
+            "Neighbor ID";
+        }
       }
     }
 
@@ -783,23 +768,6 @@ submodule ietf-bgp-ls-topo-attr {
 
     uses bgp-ls-topo-srv6-endpoint-behavior-attr;
     uses bgp-ls-topo-srv6-sid-struct-attr;
-  }
-
-  grouping bgp-ls-topo-srv6-lan-end-x-sid-attr {
-    description
-      "Grouping for the BGP-LS topology SRv6 LAN End.X SID
-       attribute";
-
-    uses bgp-ls-topo-srv6-end-x-sid-attr;
-
-    leaf neighbor-id {
-      type union {
-        type inet:ipv4-address;
-        type ietf-isis-t:system-id;
-      }
-      description
-        "Neighbor ID";
-    }
   }
 
   grouping bgp-ls-topo-unknown-attr {
@@ -1774,7 +1742,16 @@ submodule ietf-bgp-ls-topo-attr {
             description
               "List of SRv6 LAN End.X SID";
 
-            uses bgp-ls-topo-srv6-lan-end-x-sid-attr;
+            uses bgp-ls-topo-srv6-end-x-sid-attr;
+
+            leaf neighbor-id {
+              type union {
+                type inet:ipv4-address;
+                type ietf-isis-t:system-id;
+              }
+              description
+                "Neighbor ID";
+            }
           }
         }
 
@@ -1824,90 +1801,6 @@ submodule ietf-bgp-ls-topo-attr {
               uses
                 bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
               uses bgp-ls-topo-common-link-l2-bundle-member-attr;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  grouping bgp-ls-topo-bgp-link-attr {
-    description
-      "Grouping for the BGP-LS topology link attributes of BGP
-       protocol";
-
-    container link-attributes {
-      description
-        "Enclosing container for link attributes list";
-
-      list link-attribute {
-        key "type";
-
-        description
-          "List of link attribute types.";
-
-        leaf type {
-          type identityref {
-            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
-          }
-          description
-            "The type of link attribute";
-        }
-
-        container bgp-peer-sids {
-          when "derived-from-or-self(../type, " +
-               "'bgp-ls-topo-t:" +
-               "bgp-ls-topo-attr-bgp-peer-node-sid')" +
-               " or derived-from-or-self(../type, " +
-               "'bgp-ls-topo-t:" +
-               "bgp-ls-topo-attr-bgp-peer-adj-sid')" +
-               " or derived-from-or-self(../type, " +
-               "'bgp-ls-topo-t:" +
-               "bgp-ls-topo-attr-bgp-peer-set-sid')" {
-            description
-              "Only include the bgp-peer-sids container when the
-               type is bgp-ls-topo-attr-bgp-peer-node-sid,
-               bgp-ls-topo-attr-bgp-peer-adj-sid, or
-               bgp-ls-topo-attr-bgp-peer-set-sid";
-          }
-          description
-            "This container contains the BGP peer Segment
-             Identifiers (SIDs) of a link";
-          reference
-            "RFC 9086: Border Gateway Protocol - Link State
-             (BGP-LS) Extensions for Segment Routing. TLV 1101,
-             TLV 1102 and TLV 1103";
-
-          list bgp-peer-sid {
-            key "label-index format";
-
-            description
-              "List of BGP peer SID";
-
-            leaf label-index {
-              type uint32;
-              description
-                "Label or index";
-            }
-
-            leaf format {
-              type bgp-ls-topo-t:bgp-peer-sid-format;
-              description
-                "Format of the SID";
-            }
-
-            leaf flags {
-              type binary {
-                length "1";
-              }
-              description
-                "Flags associated with the BGP peer SID";
-            }
-
-            leaf weight {
-              type uint8;
-              description
-                "Weight used for load balancing purposes";
             }
           }
         }
@@ -2136,7 +2029,7 @@ submodule ietf-bgp-ls-topo-attr {
             }
 
             leaf format {
-              type bgp-ls-topo-t:pfx-sid-format;
+              type bgp-ls-topo-t:sid-format;
               description
                 "Format of the SID";
             }
@@ -2398,75 +2291,6 @@ submodule ietf-bgp-ls-topo-attr {
              Engineering Information Using BGP.";
 
           uses bgp-ls-topo-unknown-attr;
-        }
-      }
-    }
-  }
-
-  grouping bgp-ls-topo-bgp-srv6-sid-attr {
-    description
-      "Grouping for the BGP-LS topology SRv6 SID attributes of
-       BGP protocol";
-
-    container srv6-sid-attributes {
-      description
-        "Enclosing container for SRv6 SID attributes list";
-
-      list srv6-sid-attribute {
-        key "type";
-
-        description
-          "List of SRv6 SID attribute types.";
-
-        leaf type {
-          type identityref {
-            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
-          }
-          description
-            "The type of SRv6 SID attribute";
-        }
-
-        uses bgp-ls-topo-srv6-sid-attr;
-
-        container srv6-bgp-peer-node-sid {
-          when "derived-from-or-self(../type, " +
-               "'bgp-ls-topo-t:" +
-               "bgp-ls-topo-attr-srv6-bgp-peer-node-sid')" {
-            description
-              "Only include the srv6-bgp-peer-node-sid container
-               when the type is
-               bgp-ls-topo-attr-srv6-bgp-peer-node-sid";
-          }
-          description
-            "This container contains the SRv6 BGP peer node SID.";
-          reference
-            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
-             Extensions for Segment Routing over IPv6 (SRv6).
-             SRv6 BGP peer node SID. TLV 1251.";
-
-          leaf flags {
-            type uint32;
-            description
-              "Flags associated with the SRv6 BGP peer node SID";
-          }
-
-          leaf weight {
-            type uint32;
-            description
-              "Weight used for load balancing purposes";
-          }
-
-          leaf peer-as {
-            type inet:as-number;
-            description
-              "Autonomous system of peer";
-          }
-
-          leaf peer-bgp-id {
-            type ietf-rt-t:router-id;
-            description
-              "BGP Router ID of peer";
-          }
         }
       }
     }

--- a/src/yang/ietf-bgp-ls-topo-attr.yang
+++ b/src/yang/ietf-bgp-ls-topo-attr.yang
@@ -1145,9 +1145,9 @@ submodule ietf-bgp-ls-topo-attr {
                        "'bgp-ls-topo-t:" +
                        "bgp-ls-topo-attr-fad-excl-any-aff')" {
                     description
-                      "Only include the exclude-any-affinity container when
-                      the type is
-                      bgp-ls-topo-attr-fad-excl-any-aff";
+                      "Only include the exclude-any-affinity
+                       container when the type is
+                       bgp-ls-topo-attr-fad-excl-any-aff";
                   }
                   description
                     "This container contains the affinity constraints
@@ -1155,9 +1155,9 @@ submodule ietf-bgp-ls-topo-attr {
                      of links carrying any of the specified affinities
                      from the computation of the specific algorithm";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1040";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1040";
 
                   uses bgp-ls-topo-eag-attr;
                 }
@@ -1173,13 +1173,14 @@ submodule ietf-bgp-ls-topo-attr {
                   }
                   description
                     "This container contains the affinity constraints
-                     associated with the FAD and enables the inclusion of
-                     links carrying any of the specified affinities from the
-                     computation of the specific algorithm";
+                     associated with the FAD and enables the
+                     inclusion of links carrying any of the specified
+                     affinities from the computation of the specific
+                     algorithm";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1041";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1041";
 
                   uses bgp-ls-topo-eag-attr;
                 }
@@ -1189,9 +1190,9 @@ submodule ietf-bgp-ls-topo-attr {
                        "'bgp-ls-topo-t:" +
                        "bgp-ls-topo-attr-fad-incl-all-aff')" {
                     description
-                      "Only include the include-all-affinity container when
-                      the type is
-                      bgp-ls-topo-attr-fad-incl-all-aff";
+                      "Only include the include-all-affinity
+                       container when the type is
+                       bgp-ls-topo-attr-fad-incl-all-aff";
                   }
                   description
                     "This container contains the affinity constraints
@@ -1199,9 +1200,9 @@ submodule ietf-bgp-ls-topo-attr {
                      of links carrying all of the specified affinities
                      from the computation of the specific algorithm";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1042";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1042";
 
                   uses bgp-ls-topo-eag-attr;
                 }
@@ -1217,18 +1218,19 @@ submodule ietf-bgp-ls-topo-attr {
                     "This container contains the flags associated with
                      the FAD";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1043";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1043";
 
                   leaf flags {
                     type binary {
                       length "1..65535";
                     }
                     description
-                      "Bit mask representing the FAD flags. The flags are
-                       derived from the IS-IS and OSPF protocol-specific
-                       Flexible Algorithm Definition Flags sub-TLV.";
+                      "Bit mask representing the FAD flags. The
+                       flags are derived from the IS-IS and OSPF
+                       protocol-specific Flexible Algorithm
+                       Definition Flags sub-TLV.";
                     reference
                       "RFC 9350: IGP Flexible Algorithm.";
                   }
@@ -1236,20 +1238,22 @@ submodule ietf-bgp-ls-topo-attr {
 
                 container exclude-srlg {
                   when "derived-from-or-self(../type, " +
-                       "'bgp-ls-topo-t:bgp-ls-topo-attr-fad-excl-srlg')" {
+                       "'bgp-ls-topo-t:" +
+                       "bgp-ls-topo-attr-fad-excl-srlg')" {
                     description
                       "Only include the exclude-srlg container when the
                        type is bgp-ls-topo-attr-fad-excl-srlg";
                   }
                   description
                     "This container contains the affinity constraints
-                     associated with the FAD and enables the exclusion of
-                     links associated with any of the specified SRLG from
-                     the computation of the specific algorithm";
+                     associated with the FAD and enables the
+                     exclusion of links associated with any of the
+                     specified SRLG from the computation of the
+                     specific algorithm";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1045";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1045";
 
                   uses bgp-ls-topo-srlg-attr;
                 }
@@ -1280,14 +1284,14 @@ submodule ietf-bgp-ls-topo-attr {
                        "'bgp-ls-topo-t:" +
                        "bgp-ls-topo-attr-fad-excl-maximum-delay')" {
                     description
-                      "Only include the exclude-maximum-delay container when
-                       the type is
+                      "Only include the exclude-maximum-delay
+                       container when the type is
                        bgp-ls-topo-attr-fad-excl-maximum-delay";
                   }
                   description
-                    "This container enables the exclusion of links having
-                    delay above a maximum specified delay from the
-                    computation of the specific algorithm";
+                    "This container enables the exclusion of links
+                     having delay above a maximum specified delay
+                     from the computation of the specific algorithm";
                   reference
                     "RFC TBD: BGP-LS extensions for IP Flexible
                      Algorithms and Bandwidth, Delay, Metrics and
@@ -1330,10 +1334,10 @@ submodule ietf-bgp-ls-topo-attr {
                   }
                   description
                     "This container contains the affinity constraints
-                     associated with the FAD and enables the inclusion of
-                     links carrying any of the specified affinities in the
-                     reverse direction from the computation of the specific
-                     algorithm";
+                     associated with the FAD and enables the
+                     inclusion of links carrying any of the specified
+                     affinities in the reverse direction from the
+                     computation of the specific algorithm";
                   reference
                     "RFC TBD: BGP-LS extensions for Flexible
                      Algorithms Reverse Affinity Constraint.
@@ -1353,10 +1357,10 @@ submodule ietf-bgp-ls-topo-attr {
                   }
                   description
                     "This container contains the affinity constraints
-                     associated with the FAD and enables the inclusion of
-                     links carrying all of the specified affinities in the
-                     reverse direction from the computation of the specific
-                     algorithm";
+                     associated with the FAD and enables the
+                     inclusion of links carrying all of the specified
+                     affinities in the reverse direction from the
+                     computation of the specific algorithm";
                   reference
                     "RFC TBD: BGP-LS extensions for Flexible
                      Algorithms Reverse Affinity Constraint.
@@ -1367,7 +1371,8 @@ submodule ietf-bgp-ls-topo-attr {
 
                 container fa-unsupported-tlvs {
                   when "derived-from-or-self(../type, " +
-                       "'bgp-ls-topo-t:bgp-ls-topo-attr-fa-unsupported')" {
+                       "'bgp-ls-topo-t:" +
+                       "bgp-ls-topo-attr-fa-unsupported')" {
                     description
                       "Only include the fa-unsupported-tlvs container
                        when the type is
@@ -1377,9 +1382,9 @@ submodule ietf-bgp-ls-topo-attr {
                     "Indicates the presence of unsupported Flexible
                      Algorithm Definition (FAD) TLVs";
                   reference
-                    "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
-                     Extensions for Flexible Algorithm Advertisement.
-                     TLV 1046";
+                    "RFC 9351: Border Gateway Protocol - Link State
+                     (BGP-LS) Extensions for Flexible Algorithm
+                     Advertisement. TLV 1046";
 
                   leaf protocol-id {
                     type bgp-ls-topo-t:protocol;

--- a/src/yang/ietf-bgp-ls-topo-attr.yang
+++ b/src/yang/ietf-bgp-ls-topo-attr.yang
@@ -649,7 +649,7 @@ submodule ietf-bgp-ls-topo-attr {
           reference
             "RFC 9294: Application-Specific Link Attributes
              Advertisement Using the Border Gateway Protocol - Link
-             State (BGP-LS), Section 3.2; RFC 8920.";
+             State (BGP-LS), Section 2";
         }
 
         leaf udabm {
@@ -664,7 +664,7 @@ submodule ietf-bgp-ls-topo-attr {
           reference
             "RFC 9294: Application-Specific Link Attributes
              Advertisement Using the Border Gateway Protocol - Link
-             State (BGP-LS), Section 3.2; RFC 8920.";
+             State (BGP-LS), Section 2;";
         }
 
         list asla-attribute {

--- a/src/yang/ietf-bgp-ls-topo-attr.yang
+++ b/src/yang/ietf-bgp-ls-topo-attr.yang
@@ -210,7 +210,7 @@ submodule ietf-bgp-ls-topo-attr {
     }
 
     leaf format {
-      type uint8;
+      type bgp-ls-topo-t:adj-sid-format;
       description
         "Format of the SID";
     }
@@ -639,17 +639,32 @@ submodule ietf-bgp-ls-topo-attr {
           "List of Application Specific Link Attributes (ASLA)";
 
         leaf sabm {
-          type uint32;
+          type binary {
+            length "0|4|8";
+          }
           description
-            "Standard Application Identifier Bit Mask (SABM). Each
-             bit represents a single standard application";
+            "Standard Application Identifier Bit Mask (SABM).
+             Optional bit mask of length 0, 4, or 8 octets where
+             each bit represents a single standard application.";
+          reference
+            "RFC 9294: Application-Specific Link Attributes
+             Advertisement Using the Border Gateway Protocol - Link
+             State (BGP-LS), Section 3.2; RFC 8920.";
         }
 
         leaf udabm {
-          type uint32;
+          type binary {
+            length "0|4|8";
+          }
           description
             "User-Defined Application Identifier Bit Mask (UDABM).
-             Each bit represents a single user-defined application";
+             Optional bit mask of length 0, 4, or 8 octets where
+             each bit represents a single user-defined
+             application.";
+          reference
+            "RFC 9294: Application-Specific Link Attributes
+             Advertisement Using the Border Gateway Protocol - Link
+             State (BGP-LS), Section 3.2; RFC 8920.";
         }
 
         list asla-attribute {
@@ -887,7 +902,7 @@ submodule ietf-bgp-ls-topo-attr {
         container include-all-affinity {
           when "derived-from-or-self(../type, " +
                "'bgp-ls-topo-t:" +
-               "bgp-ls-topo-attr-fad-incl-any-aff')" {
+               "bgp-ls-topo-attr-fad-incl-all-aff')" {
             description
               "Only include the include-all-affinity container when 
               the type is 
@@ -1249,7 +1264,7 @@ submodule ietf-bgp-ls-topo-attr {
 
           leaf name {
             type string {
-              length "1..65535";
+              length "1..255";
             }
             description
               "Node name";
@@ -1332,17 +1347,6 @@ submodule ietf-bgp-ls-topo-attr {
               description
                 "Number of labels in the range";
             }
-          }
-
-          leaf isis-flags {
-            type binary {
-              length "1";
-            }
-            description
-              "ISIS flags for IS-IS.";
-            reference
-              "RFC 8667: IS-IS Extensions for Segment Routing,
-               Section 3.3.";
           }
         }
 
@@ -1502,7 +1506,6 @@ submodule ietf-bgp-ls-topo-attr {
             "The type of link attribute";
         }
 
-        uses bgp-ls-topo-common-link-l2-bundle-member-attr;
         uses bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
 
         container link-local-remote-identifiers {
@@ -1719,7 +1722,7 @@ submodule ietf-bgp-ls-topo-attr {
 
           leaf name {
             type string {
-              length "1..65535";
+              length "1..255";
             }
             description
               "Link name";
@@ -1783,6 +1786,8 @@ submodule ietf-bgp-ls-topo-attr {
           }
         }
 
+        uses bgp-ls-topo-common-link-l2-bundle-member-attr;
+
         container l2-bundle-members {
           when "derived-from-or-self(../type, " +
                "'bgp-ls-topo-t:" +
@@ -1824,9 +1829,9 @@ submodule ietf-bgp-ls-topo-attr {
                   "The type of bundle member attribute";
               }
 
-              uses bgp-ls-topo-common-link-l2-bundle-member-attr;
               uses
                 bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
+              uses bgp-ls-topo-common-link-l2-bundle-member-attr;
             }
           }
         }
@@ -1894,7 +1899,7 @@ submodule ietf-bgp-ls-topo-attr {
             }
 
             leaf format {
-              type uint8;
+              type bgp-ls-topo-t:bgp-peer-sid-format;
               description
                 "Format of the SID";
             }
@@ -2139,7 +2144,7 @@ submodule ietf-bgp-ls-topo-attr {
             }
 
             leaf format {
-              type uint8;
+              type bgp-ls-topo-t:pfx-sid-format;
               description
                 "Format of the SID";
             }
@@ -2360,6 +2365,10 @@ submodule ietf-bgp-ls-topo-attr {
           }
           description
             "This container contains the SRv6 endpoint behavior.";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             SRv6 endpoint behavior. TLV 1250.";
 
           uses bgp-ls-topo-srv6-endpoint-behavior-attr;
         }
@@ -2375,6 +2384,10 @@ submodule ietf-bgp-ls-topo-attr {
           }
           description
             "This container defines the SRv6 SID structure.";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             SRv6 SID structure. TLV 1252.";
 
           uses bgp-ls-topo-srv6-sid-struct-attr;
         }
@@ -2434,6 +2447,10 @@ submodule ietf-bgp-ls-topo-attr {
           }
           description
             "This container contains the SRv6 BGP peer node SID.";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             SRv6 BGP peer node SID. TLV 1251.";
 
           leaf flags {
             type uint32;

--- a/src/yang/ietf-bgp-ls-topo-attr.yang
+++ b/src/yang/ietf-bgp-ls-topo-attr.yang
@@ -188,43 +188,267 @@ submodule ietf-bgp-ls-topo-attr {
     }
   }
 
-  grouping bgp-ls-topo-common-node-link-attr {
+  grouping bgp-ls-topo-metric-attr {
     description
-      "Grouping for the BGP-LS topology common node and link
-       attributes";
+      "Grouping for the BGP-LS topology metric attribute";
 
-    container local-ipv4-router-ids {
-      when "derived-from-or-self(../type, " +
-          "'bgp-ls-topo-t:bgp-ls-topo-attr-local-ipv4-routerid')" {
+    leaf metric {
+      type uint32;
       description
-          "Only include the local-ipv4-router-ids container when the
-           type is bgp-ls-topo-attr-local-ipv4-routerid";
-      }      
-      description
-        "This container describes the auxiliary Router-IDs used
-         by the IGP.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP. TLV 1028";
+        "Metric";
+    }
+  }
 
-      uses bgp-ls-topo-ipv4-router-id-attr;
+  grouping bgp-ls-topo-adj-sid-attr {
+    description
+      "Grouping for the BGP-LS topology adjacency SID attribute";
+
+    leaf label-index {
+      type uint32;
+      description
+        "Label or index";
     }
 
-    container local-ipv6-router-ids {
+    leaf format {
+      type uint8;
+      description
+        "Format of the SID";
+    }
+
+    leaf flags {
+      type binary {
+        length "1";
+      }
+      description
+        "Flags associated with the SID. IS-IS flags are
+         defined in RFC 8667. OSPFv2 flags are defined in
+         RFC 8665. OSPFv3 flags are defined in RFC 8666.";
+    }
+
+    leaf weight {
+      type uint8;
+      description
+        "Weight used for load balancing purposes";
+    }
+  }
+
+  grouping bgp-ls-topo-lan-adj-sid-attr {
+    description
+      "Grouping for the BGP-LS topology LAN adjacency SID
+       attribute";
+
+    uses bgp-ls-topo-adj-sid-attr;
+
+    leaf neighbor-id {
+      type union {
+        type inet:ipv4-address;
+        type ietf-isis-t:system-id;
+      }
+      description
+        "Neighbor ID";
+    }
+  }
+
+  grouping bgp-ls-topo-common-link-asla-l2-bundle-member-attr {
+    description
+      "Grouping for the BGP-LS topology attributes common for link,
+       ASLA and L2 bundle member";
+
+    container te-default-metric {
       when "derived-from-or-self(../type, " +
-          "'bgp-ls-topo-t:bgp-ls-topo-attr-local-ipv6-routerid')" {
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-te-default-metric')" {
+        description
+          "Only include the te-default-metric container when the
+           type is bgp-ls-topo-attr-te-default-metric";
+      }
       description
-          "Only include the local-ipv6-router-ids container when the
-           type is bgp-ls-topo-attr-local-ipv6-routerid";
-      }      
-      description
-        "This container describes the auxiliary Router-IDs used
-         by the IGP.";
+        "This container specifies the Traffic Engineering (TE)
+         metric of a link";
       reference
         "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP. TLV 1029";
+         Engineering Information Using BGP. TLV 1092";
 
-      uses bgp-ls-topo-ipv6-router-id-attr;
+      uses bgp-ls-topo-metric-attr;
+    }
+
+    container unidirectional-link-delay {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-link-delay')" {
+        description
+          "Only include the unidirectional-link-delay container
+           when the type is bgp-ls-topo-attr-unidir-link-delay";
+      }
+      description
+        "This container specifies the average link delay between
+         two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1114";
+
+      uses bgp-ls-topo-delay-attr;
+
+      leaf anomaly {
+        type boolean;
+        description
+          "Anomalous?";
+      }
+    }
+
+    container min-max-unidirectional-link-delay {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-min-max-unidir-link-delay')" {
+        description
+          "Only include the min-max-unidirectional-link-delay
+           container when the type is
+           bgp-ls-topo-attr-min-max-unidir-link-delay";
+      }
+      description
+        "This container specifies the minimum and maximum link delay
+         between two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1115";
+
+      container min {
+        description
+          "Enclosing container for minimum delay";
+        uses bgp-ls-topo-delay-attr;
+      }
+
+      container max {
+        description
+          "Enclosing container for maximum delay";
+        uses bgp-ls-topo-delay-attr;
+      }
+
+      leaf anomaly {
+        type boolean;
+        description
+          "Anomalous?";
+      }
+    }
+
+    container unidirectional-delay-variation {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-delay-variation')" {
+        description
+          "Only include the unidirectional-delay-variation container
+           when the type is
+           bgp-ls-topo-attr-unidir-delay-variation";
+      }
+      description
+        "This container specifies the average link delay variation
+         between two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1116";
+
+      uses bgp-ls-topo-delay-attr;
+    }
+
+    container unidirectional-link-loss {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-link-loss')" {
+        description
+          "Only include the unidirectional-link-loss container when
+           the type is bgp-ls-topo-attr-unidir-link-loss";
+      }
+      description
+        "This container specifies the loss (as a packet percentage)
+         between two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1117";
+
+      leaf link-loss {
+        type uint32;
+        description
+          "Link packet loss as a percentage of the total traffic
+           sent over a configurable interval. The basic unit is
+           0.000003%, where (2^24 - 2) is 50.331642%.";
+      }
+
+      leaf anomaly {
+        type boolean;
+        description
+          "Anomalous?";
+      }
+    }
+
+    container unidirectional-residual-bw {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-residual-bw')" {
+        description
+          "Only include the unidirectional-residual-bw container
+           when the type is bgp-ls-topo-attr-unidir-residual-bw";
+      }
+      description
+        "This container specifies the residual bandwidth between
+         two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1118";
+
+      uses bgp-ls-topo-bw-attr;
+    }
+
+    container unidirectional-available-bw {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-available-bw')" {
+        description
+          "Only include the unidirectional-available-bw container
+           when the type is bgp-ls-topo-attr-unidir-available-bw";
+      }
+      description
+        "This container specifies the available bandwidth between
+         two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1119";
+
+      uses bgp-ls-topo-bw-attr;
+    }
+
+    container unidirectional-utilized-bw {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-unidir-utilized-bw')" {
+        description
+          "Only include the unidirectional-utilized-bw container
+           when the type is bgp-ls-topo-attr-unidir-utilized-bw";
+      }
+      description
+        "This container specifies the utilized bandwidth between
+         two directly connected IGP link-state neighbors";
+      reference
+        "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+         Engineering Performance Metric Extensions. TLV 1120";
+
+      uses bgp-ls-topo-bw-attr;
+    }
+
+    container extended-admin-group {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-extended-admin-group')" {
+        description
+          "Only include the extended-admin-group container when the
+           type is bgp-ls-topo-attr-extended-admin-group";
+      }
+      description
+        "This container contains the bit mask of administrative
+         groups assigned by the network administrator";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP. TLV 1173";
+
+      uses bgp-ls-topo-eag-attr;
     }
 
     container unknowns {
@@ -233,38 +457,364 @@ submodule ietf-bgp-ls-topo-attr {
       description
           "Only include the unknowns container when the type is
           bgp-ls-topo-attr-unknowns";
-      }      
+      }
       description
         "This container describes the unknown attributes.";
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP.";
 
-      list unknown {
-        key "type";
-        
-        description 
-          "List of node FAD attribute types.";
-        
-        leaf type {
-          type uint16;
+      uses bgp-ls-topo-unknown-attr;
+    }
+  }
+
+  grouping bgp-ls-topo-common-link-l2-bundle-member-attr {
+    description
+      "Grouping for the BGP-LS topology attributes common for link
+       and L2 bundle member";
+
+    container maximum-link-bw {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-maximum-link-bw')" {
+        description
+          "Only include the maximum-link-bw container when the
+           type is bgp-ls-topo-attr-maximum-link-bw";
+      }
+      description
+        "This container specifies the maximum bandwidth that can be
+         used on a link";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP. TLV 1089";
+
+      uses bgp-ls-topo-bw-attr;
+    }
+
+    container maximum-reservable-link-bw {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-maximum-reservable-link-bw')" {
+        description
+          "Only include the maximum-reservable-link-bw container
+           when the type is
+           bgp-ls-topo-attr-maximum-reservable-link-bw";
+      }
+      description
+        "This container specifies the maximum bandwidth that can be
+         reserved on a link";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP. TLV 1090";
+
+      uses bgp-ls-topo-bw-attr;
+    }
+
+    container unreserved-bws {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-unreserved-bw')" {
+        description
+          "Only include the unreserved-bws container when the type
+           is bgp-ls-topo-attr-unreserved-bw";
+      }
+      description
+        "This container specifies the bandwidth reservable on a
+         link on a per priority basis";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP. TLV 1091";
+
+      list unreserved-bw {
+        key "priority";
+
+        description
+          "List of unreserved bandwidths";
+
+        leaf priority {
+          type uint8 {
+            range "0..7";
+          }
           description
-            "Attribute type.";
-          reference
-            "RFC 9552: Distribution of Link-State and Traffic
-             Engineering Information Using BGP, Section 5.3.";
+            "Priority level";
         }
 
-        leaf value {
-          type yang:hex-string;
+        leaf bandwidth {
+          type ietf-rt-t:bandwidth-ieee-float32;
           description
-            "Attribute value.";
-          reference
-            "RFC 9552: Distribution of Link-State and Traffic
-             Engineering Information Using BGP, Section 5.3.";
+            "Bandwidth reservable on the link for a particular
+             priority";
         }
       }
-    }    
+    }
+
+    container link-protection-type {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:" +
+           "bgp-ls-topo-attr-link-protection-type')" {
+        description
+          "Only include the link-protection-type container when the
+           type is bgp-ls-topo-attr-link-protection-type";
+      }
+      description
+        "This container describes the protection capabilities of a
+         link";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP. TLV 1093";
+
+      leaf type {
+        type uint16;
+        description
+          "Bit mask of protection capabilities";
+      }
+    }
+
+    container adjacency-sids {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-adjacency-sid')" {
+        description
+          "Only include the adjacency-sids container when the type
+           is bgp-ls-topo-attr-adjacency-sid";
+      }
+      description
+        "This container contains the Adjacency Segment Identifiers
+         (SIDs) of an adjacency";
+      reference
+        "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+         Extensions for Segment Routing. TLV 1099";
+
+      list adjacency-sid {
+        key "label-index format";
+
+        description
+          "List of adjacency SID";
+
+        uses bgp-ls-topo-adj-sid-attr;
+      }
+    }
+
+    container lan-adjacency-sids {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-lan-adjacency-sid')" {
+        description
+          "Only include the lan-adjacency-sids container when the
+           type is bgp-ls-topo-attr-lan-adjacency-sid";
+      }
+      description
+        "This container contains the Adjacency Segment Identifiers
+         (SIDs) of an adjacency to any node in a LAN other than the
+         pseudonode";
+      reference
+        "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+         Extensions for Segment Routing. TLV 1100";
+
+      list adjacency-sid {
+        key "label-index format";
+
+        description
+          "List of LAN adjacency SID";
+
+        uses bgp-ls-topo-lan-adj-sid-attr;
+      }
+    }
+
+    container aslas {
+      when "derived-from-or-self(../type, " +
+           "'bgp-ls-topo-t:bgp-ls-topo-attr-asla')" {
+        description
+          "Only include the aslas container when the type is
+           bgp-ls-topo-attr-asla";
+      }
+      description
+        "This container acts as a container for link attributes
+         that require application-specific definition";
+      reference
+        "RFC 9294: Application-Specific Link Attributes
+         Advertisement Using the Border Gateway Protocol - Link
+         State (BGP-LS). TLV 1122";
+
+      list asla {
+        key "sabm udabm";
+
+        description
+          "List of Application Specific Link Attributes (ASLA)";
+
+        leaf sabm {
+          type uint32;
+          description
+            "Standard Application Identifier Bit Mask (SABM). Each
+             bit represents a single standard application";
+        }
+
+        leaf udabm {
+          type uint32;
+          description
+            "User-Defined Application Identifier Bit Mask (UDABM).
+             Each bit represents a single user-defined application";
+        }
+
+        list asla-attribute {
+          key "type";
+
+          description
+            "List of ASLA attribute types.";
+
+          leaf type {
+            type identityref {
+              base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+            }
+            description
+              "The type of ASLA attribute";
+          }
+
+          container srlgs {
+            when "derived-from-or-self(../type, " +
+                 "'bgp-ls-topo-t:bgp-ls-topo-attr-srlg')" {
+              description
+                "Only include the srlgs container when the type is
+                 bgp-ls-topo-attr-srlg";
+            }
+            description
+              "This container specifies the Shared Risk Link Groups
+               (SRLGs) of a link";
+            reference
+              "RFC 9552: Distribution of Link-State and Traffic
+               Engineering Information Using BGP. TLV 1096";
+
+            uses bgp-ls-topo-srlg-attr;
+          }
+
+          uses bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-srv6-sid-struct-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 SID
+       structure attribute";
+
+    leaf locator-block-len {
+      type uint8;
+      units "bits";
+      description
+        "Locator block length";
+    }
+
+    leaf locator-node-len {
+      type uint8;
+      units "bits";
+      description
+        "Locator node length";
+    }
+
+    leaf function-len {
+      type uint8;
+      units "bits";
+      description
+        "Function length";
+    }
+
+    leaf arg-len {
+      type uint8;
+      units "bits";
+      description
+        "Argument length";
+    }
+  }
+
+  grouping bgp-ls-topo-srv6-endpoint-behavior-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 endpoint
+       behavior attribute";
+
+    leaf endpoint-behavior {
+      type uint8;
+      description
+        "Endpoint behavior of the SID";
+    }
+
+    leaf flags {
+      type binary {
+        length "1";
+      }
+      description
+        "Flags associated with the SRv6 endpoint behavior";
+    }
+
+    leaf algorithm {
+      type uint8;
+      description
+        "Algorithm associated with the SID";
+    }
+  }
+
+  grouping bgp-ls-topo-srv6-end-x-sid-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 End.X SID
+       attribute";
+
+    leaf sid {
+      type inet:ipv6-address;
+      description
+        "SRv6 SID as a 128-bit value";
+    }
+
+    leaf weight {
+      type uint8;
+      description
+        "Weight associated with the SID for load balancing purpose";
+    }
+
+    uses bgp-ls-topo-srv6-endpoint-behavior-attr;
+    uses bgp-ls-topo-srv6-sid-struct-attr;
+  }
+
+  grouping bgp-ls-topo-srv6-lan-end-x-sid-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 LAN End.X SID
+       attribute";
+
+    uses bgp-ls-topo-srv6-end-x-sid-attr;
+
+    leaf neighbor-id {
+      type union {
+        type inet:ipv4-address;
+        type ietf-isis-t:system-id;
+      }
+      description
+        "Neighbor ID";
+    }
+  }
+
+  grouping bgp-ls-topo-unknown-attr {
+    description
+      "Grouping for the BGP-LS topology unknown attributes";
+
+    list unknown {
+      key "type";
+
+      description
+        "List of node FAD attribute types.";
+
+      leaf type {
+        type uint16;
+        description
+          "Attribute type.";
+        reference
+          "RFC 9552: Distribution of Link-State and Traffic
+           Engineering Information Using BGP, Section 5.3.";
+      }
+
+      leaf value {
+        type yang:hex-string;
+        description
+          "Attribute value.";
+        reference
+          "RFC 9552: Distribution of Link-State and Traffic
+           Engineering Information Using BGP, Section 5.3.";
+      }
+    }
   }
 
   grouping bgp-ls-topo-node-fad-attr {
@@ -569,7 +1119,59 @@ submodule ietf-bgp-ls-topo-attr {
             "The type of node attribute";
         }
 
-        uses bgp-ls-topo-common-node-link-attr;
+        container local-ipv4-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-local-ipv4-routerid')" {
+            description
+              "Only include the local-ipv4-router-ids container
+               when the type is
+               bgp-ls-topo-attr-local-ipv4-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs used
+             by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1028";
+
+          uses bgp-ls-topo-ipv4-router-id-attr;
+        }
+
+        container local-ipv6-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-local-ipv6-routerid')" {
+            description
+              "Only include the local-ipv6-router-ids container
+               when the type is
+               bgp-ls-topo-attr-local-ipv6-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs used
+             by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1029";
+
+          uses bgp-ls-topo-ipv6-router-id-attr;
+        }
+
+        container unknowns {
+          when "derived-from-or-self(../type, " +
+              "'bgp-ls-topo-t:bgp-ls-topo-attr-unknowns')" {
+          description
+              "Only include the unknowns container when the type is
+              bgp-ls-topo-attr-unknowns";
+          }
+          description
+            "This container describes the unknown attributes.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP.";
+
+          uses bgp-ls-topo-unknown-attr;
+        }
 
         container multi-topology-ids {
           when "derived-from-or-self(../type, " +
@@ -851,6 +1453,1010 @@ submodule ietf-bgp-ls-topo-attr {
             type ietf-isis-t:area-address;
             description
             "List of ISIS area addresses";
+          }
+        }
+
+        container srv6-capabilities-flags {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-srv6-cap-flags')" {
+            description
+              "Only include the srv6-cap-flags container when the
+               type is bgp-ls-topo-attr-srv6-cap-flags";
+          }
+          description
+            "This container defines SRv6 capability flags.";
+          reference
+            "RFC 9514: SRv6 BGP-LS extensions.";
+
+          leaf flags {
+            type binary {
+              length "1";
+            }
+            description
+              "SRv6 capability flags.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-igp-link-attr {
+    description
+      "Grouping for the BGP-LS topology link attributes";
+
+    container link-attributes {
+      description
+        "Enclosing container for link attributes list";
+
+      list link-attribute {
+        key "type";
+
+        description
+          "List of link attribute types.";
+
+        leaf type {
+          type identityref {
+            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+          }
+          description
+            "The type of link attribute";
+        }
+
+        uses bgp-ls-topo-common-link-l2-bundle-member-attr;
+        uses bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
+
+        container link-local-remote-identifiers {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-link-local-remote-identifiers')" {
+            description
+              "Only include the link-local-remote-identifiers
+               container when the type is
+               bgp-ls-topo-attr-link-local-remote-identifiers";
+          }
+          description
+            "This container defines link local and remote
+             identifiers.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 258";
+
+          leaf local-identifier {
+            type uint32;
+            description
+              "Link local identifier";
+          }
+
+          leaf remote-identifier {
+            type uint32;
+            description
+              "Link remote identifier";
+          }
+        }
+
+        container link-msd {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-link-msd')" {
+            description
+              "Only include the link-msd container when the type is
+               bgp-ls-topo-attr-link-msd";
+          }
+          description
+            "This container defines link Maximum SID Depth (MSD).";
+          reference
+            "RFC 8814: Signaling Maximum SID Depth (MSD) Using the
+             Border Gateway Protocol - Link State. TLV 267";
+
+          uses bgp-ls-topo-msd-attr;
+        }
+
+        container local-ipv4-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-local-ipv4-routerid')" {
+            description
+              "Only include the local-ipv4-router-ids container
+               when the type is
+               bgp-ls-topo-attr-local-ipv4-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs used
+             by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1028";
+
+          uses bgp-ls-topo-ipv4-router-id-attr;
+        }
+
+        container local-ipv6-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-local-ipv6-routerid')" {
+            description
+              "Only include the local-ipv6-router-ids container
+               when the type is
+               bgp-ls-topo-attr-local-ipv6-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs used
+             by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1029";
+
+          uses bgp-ls-topo-ipv6-router-id-attr;
+        }
+
+        container remote-ipv4-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-remote-ipv4-routerid')" {
+            description
+              "Only include the remote-ipv4-router-ids container
+               when the type is
+               bgp-ls-topo-attr-remote-ipv4-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs
+             used by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1030";
+
+          uses bgp-ls-topo-ipv4-router-id-attr;
+        }
+
+        container remote-ipv6-router-ids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-remote-ipv6-routerid')" {
+            description
+              "Only include the remote-ipv6-router-ids container
+               when the type is
+               bgp-ls-topo-attr-remote-ipv6-routerid";
+          }
+          description
+            "This container describes the auxiliary Router-IDs
+             used by the IGP.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1031";
+
+          uses bgp-ls-topo-ipv6-router-id-attr;
+        }
+
+        container mpls-protocol-mask {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-mpls-protocol-mask')" {
+            description
+              "Only include the mpls-protocol-mask container when
+               the type is bgp-ls-topo-attr-mpls-protocol-mask";
+          }
+          description
+            "This container contains the bit mask describing MPLS
+             signaling protocols enabled";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1094";
+
+          leaf mask {
+            type uint8;
+            description
+              "Bit mask of MPLS signaling protocols enabled";
+          }
+        }
+
+        container igp-metric {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-igp-metric')" {
+            description
+              "Only include the igp-metric container when the type
+               is bgp-ls-topo-attr-igp-metric";
+          }
+          description
+            "This container specifies the metric of a link";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1095";
+
+          leaf metric {
+            type uint32;
+            description
+              "IGP metric";
+          }
+        }
+
+        container srlgs {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-srlg')" {
+            description
+              "Only include the srlgs container when the type is
+               bgp-ls-topo-attr-srlg";
+          }
+          description
+            "This container specifies the Shared Risk Link Groups
+             (SRLGs) of a link";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1096";
+
+          uses bgp-ls-topo-srlg-attr;
+        }
+
+        container opaque-link-attribute {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-opaque-link')" {
+            description
+              "Only include the opaque-link-attribute container
+               when the type is bgp-ls-topo-attr-opaque-link";
+          }
+          description
+            "This container defines an envelope that transparently
+             carries optional Link Attribute TLVs advertised by a
+             router";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1097";
+
+          uses bgp-ls-topo-opaque-attribute;
+        }
+
+        container link-name {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-link-name')" {
+            description
+              "Only include the link-name container when the
+               type is bgp-ls-topo-attr-link-name";
+          }
+          description
+            "This container identifies the symbolic name of
+             the link";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1098";
+
+          leaf name {
+            type string {
+              length "1..65535";
+            }
+            description
+              "Link name";
+          }
+        }
+
+        container srv6-end-x-sids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-srv6-end-x-sid')" {
+            description
+              "Only include the srv6-end-x-sids container when the
+               type is bgp-ls-topo-attr-srv6-end-x-sid";
+          }
+          description
+            "This container contains the Segment Routing over IPv6
+             (SRv6) Segment Identifiers (SIDs) associated with an
+             adjacency.";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             TLV 1106";
+
+          list srv6-end-x-sid {
+            key "sid";
+
+            description
+              "List of SRv6 End.X SID";
+
+            uses bgp-ls-topo-srv6-end-x-sid-attr;
+          }
+        }
+
+        container srv6-lan-end-x-sids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-srv6-isis-lan-end-x-sid')" +
+               " or derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-srv6-ospf-lan-end-x-sid')" {
+            description
+              "Only include the srv6-lan-end-x-sids container when
+               the type is bgp-ls-topo-attr-srv6-isis-lan-end-x-sid
+               or bgp-ls-topo-attr-srv6-ospf-lan-end-x-sid";
+          }
+          description
+            "This container contains the Segment Routing over IPv6
+             (SRv6) Segment Identifiers (SIDs) of an adjacency to
+             any node in a LAN other than the pseudonode";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             TLV 1107 / 1108";
+
+          list srv6-end-x-sid {
+            key "sid";
+
+            description
+              "List of SRv6 LAN End.X SID";
+
+            uses bgp-ls-topo-srv6-lan-end-x-sid-attr;
+          }
+        }
+
+        container l2-bundle-members {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-l2-bundle-member')" {
+            description
+              "Only include the l2-bundle-members container when
+               the type is bgp-ls-topo-attr-l2-bundle-member";
+          }
+          description
+            "This container identifies an L2 bundle member link
+             that is associated with a parent L3 link";
+          reference
+            "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing. TLV 1172";
+
+          list l2-bundle-member {
+            key "member-descriptor";
+
+            description
+              "List of L2 bundle members";
+
+            leaf member-descriptor {
+              type uint32;
+              description
+                "Link local identifier";
+            }
+
+            list bundle-member-attribute {
+              key "type";
+
+              description
+                "List of bundle member attribute types.";
+
+              leaf type {
+                type identityref {
+                  base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+                }
+                description
+                  "The type of bundle member attribute";
+              }
+
+              uses bgp-ls-topo-common-link-l2-bundle-member-attr;
+              uses
+                bgp-ls-topo-common-link-asla-l2-bundle-member-attr;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-bgp-link-attr {
+    description
+      "Grouping for the BGP-LS topology link attributes of BGP
+       protocol";
+
+    container link-attributes {
+      description
+        "Enclosing container for link attributes list";
+
+      list link-attribute {
+        key "type";
+
+        description
+          "List of link attribute types.";
+
+        leaf type {
+          type identityref {
+            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+          }
+          description
+            "The type of link attribute";
+        }
+
+        container bgp-peer-sids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-bgp-peer-node-sid')" +
+               " or derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-bgp-peer-adj-sid')" +
+               " or derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-bgp-peer-set-sid')" {
+            description
+              "Only include the bgp-peer-sids container when the
+               type is bgp-ls-topo-attr-bgp-peer-node-sid,
+               bgp-ls-topo-attr-bgp-peer-adj-sid, or
+               bgp-ls-topo-attr-bgp-peer-set-sid";
+          }
+          description
+            "This container contains the BGP peer Segment
+             Identifiers (SIDs) of a link";
+          reference
+            "RFC 9086: Border Gateway Protocol - Link State
+             (BGP-LS) Extensions for Segment Routing. TLV 1101,
+             TLV 1102 and TLV 1103";
+
+          list bgp-peer-sid {
+            key "label-index format";
+
+            description
+              "List of BGP peer SID";
+
+            leaf label-index {
+              type uint32;
+              description
+                "Label or index";
+            }
+
+            leaf format {
+              type uint8;
+              description
+                "Format of the SID";
+            }
+
+            leaf flags {
+              type binary {
+                length "1";
+              }
+              description
+                "Flags associated with the BGP peer SID";
+            }
+
+            leaf weight {
+              type uint8;
+              description
+                "Weight used for load balancing purposes";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-prefix-attr {
+    description
+      "Grouping for the BGP-LS topology prefix attributes";
+
+    container prefix-attributes {
+      description
+        "Enclosing container for prefix attributes list";
+
+      list prefix-attribute {
+        key "type";
+
+        description
+          "List of prefix attribute types.";
+
+        leaf type {
+          type identityref {
+            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+          }
+          description
+            "The type of prefix attribute";
+        }
+
+        container flexible-algorithm-prefix-metric {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-fa-prefix-metric')" {
+            description
+              "Only include the flexible-algorithm-prefix-metric
+               container when the type is
+               bgp-ls-topo-attr-fa-prefix-metric";
+          }
+          description
+            "This container defines the metric associated with the
+             prefix for a particular Flexible Algorithm (FA)";
+          reference
+            "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Flexible Algorithm Advertisement.
+             TLV 1044";
+
+          list fa-prefix-metric {
+            key "algorithm";
+
+            description
+              "List of Flexible Algorithm prefix metrics";
+
+            leaf metric {
+              type uint32;
+              description
+                "Flexible Algorithm prefix metric";
+            }
+
+            leaf algorithm {
+              type uint8 {
+                range "128..255";
+              }
+              description
+                "Flexible Algorithm";
+            }
+
+            leaf flags {
+              type binary {
+                length "1";
+              }
+              description
+                "Flags associated with the Flexible Algorithm prefix
+                 metric as defined in RFC 9350 for OSPFv2";
+            }
+          }
+        }
+
+        container igp-flags {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-igp-flags')" {
+            description
+              "Only include the igp-flags container when the type is
+               bgp-ls-topo-attr-igp-flags";
+          }
+          description
+            "This container specifies the flags and bits assigned
+             to a prefix";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1152";
+
+          leaf flags {
+            type bgp-ls-topo-t:igp-flags-bits;
+            description
+              "IGP flags";
+          }
+        }
+
+        container igp-route-tags {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-igp-route-tag')" {
+            description
+              "Only include the igp-route-tags container when the
+               type is bgp-ls-topo-attr-igp-route-tag";
+          }
+          description
+            "This container specifies the tags of a prefix";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1153";
+
+          leaf-list tag {
+            type uint32;
+            description
+              "List of IGP route tags";
+          }
+        }
+
+        container extended-igp-route-tags {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-ext-igp-route-tag')" {
+            description
+              "Only include the extended-igp-route-tags container
+               when the type is bgp-ls-topo-attr-ext-igp-route-tag";
+          }
+          description
+            "This container specifies the extended route tags of a
+             prefix";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1154";
+
+          leaf-list tag {
+            type uint64;
+            description
+              "List of IGP extended route tags";
+          }
+        }
+
+        container prefix-metric {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-prefix-metric')" {
+            description
+              "Only include the prefix-metric container when the
+               type is bgp-ls-topo-attr-prefix-metric";
+          }
+          description
+            "This container specifies the metric of a prefix";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1155";
+
+          leaf metric {
+            type uint32;
+            description
+              "Prefix metric";
+          }
+        }
+
+        container ospf-forwarding-address {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-ospf-forwarding-address')" {
+            description
+              "Only include the ospf-forwarding-address container
+               when the type is
+               bgp-ls-topo-attr-ospf-forwarding-address";
+          }
+          description
+            "This container specifies the forwarding address of a
+             prefix as known in original OSPF advertisement";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1156";
+
+          leaf forw-address {
+            type inet:ip-address;
+            description
+              "Forwarding address";
+          }
+        }
+
+        container opaque-prefix-attribute {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-opaque-prefix')" {
+            description
+              "Only include the opaque-prefix-attribute container
+               when the type is bgp-ls-topo-attr-opaque-prefix";
+          }
+          description
+            "This container defines an envelope that transparently
+             carries optional Prefix Attribute TLVs advertised by a
+             router";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP. TLV 1157";
+
+          uses bgp-ls-topo-opaque-attribute;
+        }
+
+        container prefix-sids {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-prefix-sid')" {
+            description
+              "Only include the prefix-sids container when the type
+               is bgp-ls-topo-attr-prefix-sid";
+          }
+          description
+            "This container contains the prefix Segment Identifiers
+             (SIDs) of a prefix";
+          reference
+            "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing. TLV 1158";
+
+          list prefix-sid {
+            key "label-index format";
+
+            description
+              "List of prefix SID";
+
+            leaf label-index {
+              type uint32;
+              description
+                "Label or index";
+            }
+
+            leaf format {
+              type uint8;
+              description
+                "Format of the SID";
+            }
+
+            leaf flags {
+              type binary {
+                length "1";
+              }
+              description
+                "Flags as defined in Section 2.1.1 of RFC 8667 for
+                 ISIS, Section 5 of RFC 8665 for OSPFv2 and
+                 Section 6 of RFC 8665 for OSPFv3";
+            }
+
+            leaf algorithm {
+              type uint8;
+              description
+                "Algorithm";
+            }
+          }
+        }
+
+        container prefix-range {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-prefix-range')" {
+            description
+              "Only include the prefix-range container when the
+               type is bgp-ls-topo-attr-prefix-range";
+          }
+          description
+            "This container defines a range of
+             prefix-to-SID mapping.";
+          reference
+            "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing. TLV 1159";
+
+          leaf index {
+            type uint32;
+            description
+              "Starting index of the range";
+          }
+
+          leaf range-size {
+            type uint16;
+            description
+              "Number of prefixes covered by the advertisement";
+          }
+
+          leaf flags {
+            type binary {
+              length "1";
+            }
+            description
+              "Flags associated with the range taken from IS-IS
+               SID/Label Binding TLV flags as defined in
+               Section 2.4.1 of RFC 8667 for ISIS, OSPFv2 OSPF
+               Extended Prefix Range TLV flags as defined in
+               Section 4 of RFC 8665 for OSPFv2 and OSPFv3
+               Extended Prefix Range TLV flags as defined in
+               Section 5 of RFC 8666 for OSPFv3";
+          }
+
+          leaf algorithm {
+            type uint8;
+            description
+              "Algorithm";
+          }
+
+          leaf sid-flags {
+            type binary {
+              length "1";
+            }
+            description
+              "Flags associated with the SID as defined in Section
+               2.1.1 of RFC 8667 for ISIS, Section 5 of RFC 8665 for
+               OSPFv2 and Section 6 of RFC 8665 for OSPFv3";
+          }
+        }
+
+        container srv6-locator {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:bgp-ls-topo-attr-srv6-locator')" {
+            description
+              "Only include the srv6-locator container when the type
+               is bgp-ls-topo-attr-srv6-locator";
+          }
+          description
+            "This container contains the Segment Routing over IPv6
+             (SRv6) locator information associated with a prefix.";
+          reference
+            "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing over IPv6 (SRv6).
+             TLV 1162";
+
+          leaf metric {
+            type uint32;
+            description
+              "Flex algo prefix metric";
+          }
+
+          leaf flags {
+            type binary {
+              length "1";
+            }
+            description
+              "Flags associated with the locator, copied from the
+               IS-IS SRv6 Locator TLV (Section 7.1 of RFC 9352) for
+               ISIS or the OSPFv3 SRv6 Locator TLV (Section 7.1 of
+               RFC 9513) for OSPFv3";
+          }
+
+          leaf algorithm {
+            type uint8;
+            description
+              "Algorithm associated with the locator";
+          }
+        }
+
+        container prefix-attribute-flags {
+          when "derived-from-or-self(../type, " +
+            "'bgp-ls-topo-t:" +
+            "bgp-ls-topo-attr-prefix-attribute-flags')" {
+            description
+              "Only include the prefix-attribute-flags container
+            when the type is
+            bgp-ls-topo-attr-prefix-attribute-flags";
+          }
+          description
+            "This container defines the prefix attribute flags of a
+             prefix";
+          reference
+            "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing. TLV 1170";
+
+          leaf flags {
+            type binary {
+              length "1";
+            }
+            description
+              "Prefix attribute flags as defined in Section 2.1 of
+               RFC 7684 for OSPFv2, Appendix A.4.1.1 of RFC 5340 for
+               OSPFv3, and Section 2.1 of RFC 7794 for IS-IS";
+          }
+        }
+
+        container prefix-source-router-id {
+          when "derived-from-or-self(../type, " +
+            "'bgp-ls-topo-t:" +
+            "bgp-ls-topo-attr-prefix-src-router-id')" {
+            description
+              "Only include the prefix-source-router-id container
+               when the type is
+               bgp-ls-topo-attr-prefix-src-router-id";
+          }
+          description
+            "This container defines the source router identifier of
+             a prefix";
+          reference
+            "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+             Extensions for Segment Routing. TLV 1171";
+
+          leaf source-router-id {
+            type inet:ip-address;
+            description
+              "Source router ID";
+          }
+        }
+
+        container unknowns {
+          when "derived-from-or-self(../type, " +
+              "'bgp-ls-topo-t:bgp-ls-topo-attr-unknowns')" {
+          description
+              "Only include the unknowns container when the type is
+              bgp-ls-topo-attr-unknowns";
+          }
+          description
+            "This container describes the unknown attributes.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP.";
+
+          uses bgp-ls-topo-unknown-attr;
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-srv6-sid-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 SID attributes";
+
+    container srv6-sid-attributes {
+      description
+        "Enclosing container for SRv6 SID attributes list";
+
+      list srv6-sid-attribute {
+        key "type";
+
+        description
+          "List of SRv6 SID attribute types.";
+
+        leaf type {
+          type identityref {
+            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+          }
+          description
+            "The type of SRv6 SID attribute";
+        }
+
+        container srv6-endpoint-behavior {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-srv6-endpoint-behavior')" {
+            description
+              "Only include the srv6-endpoint-behavior container
+               when the type is
+               bgp-ls-topo-attr-srv6-endpoint-behavior";
+          }
+          description
+            "This container contains the SRv6 endpoint behavior.";
+
+          uses bgp-ls-topo-srv6-endpoint-behavior-attr;
+        }
+
+        container srv6-sid-structure {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-srv6-sid-structure')" {
+            description
+              "Only include the srv6-sid-structure container
+               when the type is
+               bgp-ls-topo-attr-srv6-sid-structure";
+          }
+          description
+            "This container defines the SRv6 SID structure.";
+
+          uses bgp-ls-topo-srv6-sid-struct-attr;
+        }
+ 
+        container unknowns {
+          when "derived-from-or-self(../type, " +
+              "'bgp-ls-topo-t:bgp-ls-topo-attr-unknowns')" {
+          description
+              "Only include the unknowns container when the type is
+              bgp-ls-topo-attr-unknowns";
+          }
+          description
+            "This container describes the unknown attributes.";
+          reference
+            "RFC 9552: Distribution of Link-State and Traffic
+             Engineering Information Using BGP.";
+
+          uses bgp-ls-topo-unknown-attr;
+        }
+      }
+    }
+  }
+
+  grouping bgp-ls-topo-bgp-srv6-sid-attr {
+    description
+      "Grouping for the BGP-LS topology SRv6 SID attributes of
+       BGP protocol";
+
+    container srv6-sid-attributes {
+      description
+        "Enclosing container for SRv6 SID attributes list";
+
+      list srv6-sid-attribute {
+        key "type";
+
+        description
+          "List of SRv6 SID attribute types.";
+
+        leaf type {
+          type identityref {
+            base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+          }
+          description
+            "The type of SRv6 SID attribute";
+        }
+
+        uses bgp-ls-topo-srv6-sid-attr;
+
+        container srv6-bgp-peer-node-sid {
+          when "derived-from-or-self(../type, " +
+               "'bgp-ls-topo-t:" +
+               "bgp-ls-topo-attr-srv6-bgp-peer-node-sid')" {
+            description
+              "Only include the srv6-bgp-peer-node-sid container
+               when the type is
+               bgp-ls-topo-attr-srv6-bgp-peer-node-sid";
+          }
+          description
+            "This container contains the SRv6 BGP peer node SID.";
+
+          leaf flags {
+            type uint32;
+            description
+              "Flags associated with the SRv6 BGP peer node SID";
+          }
+
+          leaf weight {
+            type uint32;
+            description
+              "Weight used for load balancing purposes";
+          }
+
+          leaf peer-as {
+            type inet:as-number;
+            description
+              "Autonomous system of peer";
+          }
+
+          leaf peer-bgp-id {
+            type ietf-rt-t:router-id;
+            description
+              "BGP Router ID of peer";
           }
         }
       }

--- a/src/yang/ietf-bgp-ls-topo-ospf.yang
+++ b/src/yang/ietf-bgp-ls-topo-ospf.yang
@@ -194,7 +194,9 @@ submodule ietf-bgp-ls-topo-ospf {
     leaf local-ipv4-address {
       type inet:ipv4-address;
       description
-        "Local IPv4 address of a link.";
+        "Local IPv4 address of a link. Use 0.0.0.0 as a sentinel
+         value when this address is not present (e.g., for
+         unnumbered or IPv6-only links).";
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
@@ -204,7 +206,9 @@ submodule ietf-bgp-ls-topo-ospf {
     leaf remote-ipv4-address {
       type inet:ipv4-address;
       description
-        "Remote IPv4 address of a link.";
+        "Remote IPv4 address of a link. Use 0.0.0.0 as a sentinel
+         value when this address is not present (e.g., for
+         unnumbered or IPv6-only links).";
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,

--- a/src/yang/ietf-bgp-ls-topo-ospf.yang
+++ b/src/yang/ietf-bgp-ls-topo-ospf.yang
@@ -160,36 +160,10 @@ submodule ietf-bgp-ls-topo-ospf {
          Section 5.2.1. TLV 515.";
     }
 
-    leaf local-dr-identifier {
-      type union {
-        type inet:ipv4-address;
-        type uint32;
-      }
-      description
-        "Local Designated Router (DR) Identifier.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1. TLV 515.";
-    }
-
     leaf remote-router-id {
       type ietf-rt-t:router-id;
       description
         "Remote Router ID.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1. TLV 515.";
-    }
-
-    leaf remote-dr-identifier {
-      type union {
-        type inet:ipv4-address;
-        type uint32;
-      }
-      description
-        "Remote Designated Router (DR) Identifier.";
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
@@ -234,26 +208,6 @@ submodule ietf-bgp-ls-topo-ospf {
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
          Section 5.2.2. TLV 260.";
-    }
-
-    leaf local-ipv6-address {
-      type inet:ipv6-address;
-      description
-        "Local IPv6 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2. TLV 261.";
-    }
-
-    leaf remote-ipv6-address {
-      type inet:ipv6-address;
-      description
-        "Remote IPv6 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2. TLV 262.";
     }
 
     leaf multi-topology-id {
@@ -308,19 +262,6 @@ submodule ietf-bgp-ls-topo-ospf {
          Section 5.2.1. TLV 515.";
     }
 
-    leaf dr-identifier {
-      type union {
-        type inet:ipv4-address;
-        type uint32;
-      }
-      description
-        "Designated Router (DR) Identifier.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1. TLV 515.";
-    }
-
     leaf route-type {
       type bgp-ls-topo-t:ospf-route-type;
       description
@@ -341,15 +282,5 @@ submodule ietf-bgp-ls-topo-ospf {
          Section 5.2.2.1. TLV 263.";
     }
 
-    leaf prefix {
-      type inet:ip-prefix;
-      description
-        "IP address prefix (IPv4 or IPv6) advertised in
-         the IGP topology.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.3.2. TLV 265.";
-    }
   }
 }

--- a/src/yang/ietf-bgp-ls-topo-ospf.yang
+++ b/src/yang/ietf-bgp-ls-topo-ospf.yang
@@ -87,7 +87,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 514.";
     }
 
     leaf router-id {
@@ -97,7 +97,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 515.";
     }
 
     leaf dr-identifier {
@@ -110,7 +110,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 515.";
     }
 
     leaf as {
@@ -121,13 +121,155 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 512.";
     }
   }
 
   grouping bgp-ls-ospf-link-common {
     description
       "Common fields for OSPFv2 and OSPFv3 link NLRIs.";
+
+    leaf area-id {
+      type ietf-ospf-t:area-id-type;
+      description
+        "Area ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 514.";
+    }
+
+    leaf as {
+      type inet:as-number;
+      description
+        "Autonomous System (AS) number associated with the
+         BGP process originating the NLRI.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 512.";
+    }
+
+    leaf local-router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Local Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 515.";
+    }
+
+    leaf local-dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Local Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 515.";
+    }
+
+    leaf remote-router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Remote Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 515.";
+    }
+
+    leaf remote-dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Remote Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1. TLV 515.";
+    }
+
+    leaf local-id {
+      type uint32;
+      description
+        "Local Identifier of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 258.";
+    }
+
+    leaf remote-id {
+      type uint32;
+      description
+        "Remote Identifier of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 258.";
+    }
+
+    leaf local-ipv4-address {
+      type inet:ipv4-address;
+      description
+        "Local IPv4 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 259.";
+    }
+
+    leaf remote-ipv4-address {
+      type inet:ipv4-address;
+      description
+        "Remote IPv4 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 260.";
+    }
+
+    leaf local-ipv6-address {
+      type inet:ipv6-address;
+      description
+        "Local IPv6 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 261.";
+    }
+
+    leaf remote-ipv6-address {
+      type inet:ipv6-address;
+      description
+        "Remote IPv6 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2. TLV 262.";
+    }
+
+    leaf multi-topology-id {
+      type uint16;
+      description
+        "Multi Topology Identifier (MTID) of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.1. TLV 263.";
+    }
+  }
+
+  grouping bgp-ls-ospf-prefix-common {
+    description
+      "Common fields for OSPFv2 and OSPFv3 prefix NLRIs.";
 
     leaf is-as-scoped {
       type boolean;
@@ -142,156 +284,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf local-as {
-      type inet:as-number;
-      description
-        "Autonomous System (AS) number associated with the
-         BGP process originating the NLRI.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf local-router-id {
-      type ietf-rt-t:router-id;
-      description
-        "Local Router ID.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf local-dr-identifier {
-      type union {
-        type inet:ipv4-address;
-        type uint32;
-      }
-      description
-        "Local Designated Router (DR) Identifier.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf remote-as {
-      type inet:as-number;
-      description
-        "Autonomous System (AS) number associated with the
-         BGP process originating the NLRI.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf remote-router-id {
-      type ietf-rt-t:router-id;
-      description
-        "Remote Router ID.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf remote-dr-identifier {
-      type union {
-        type inet:ipv4-address;
-        type uint32;
-      }
-      description
-        "Remote Designated Router (DR) Identifier.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.1.";
-    }
-
-    leaf local-id {
-      type uint32;
-      description
-        "Local Identifier of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf remote-id {
-      type uint32;
-      description
-        "Remote Identifier of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf local-ipv4-address {
-      type inet:ipv4-address;
-      description
-        "Local IPv4 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf remote-ipv4-address {
-      type inet:ipv4-address;
-      description
-        "Remote IPv4 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf local-ipv6-address {
-      type inet:ipv6-address;
-      description
-        "Local IPv6 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf remote-ipv6-address {
-      type inet:ipv6-address;
-      description
-        "Remote IPv6 address of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.";
-    }
-
-    leaf multi-topology-id {
-      type uint16;
-      description
-        "Multi Topology Identifier (MTID) of a link.";
-      reference
-        "RFC 9552: Distribution of Link-State and Traffic
-         Engineering Information Using BGP,
-         Section 5.2.2.1.";
-    }
-  }
-
-  grouping bgp-ls-ospf-prefix-common {
-    description
-      "Common fields for OSPFv2 and OSPFv3 prefix NLRIs.";
-
-    leaf is-as-scoped {
-      type boolean;
-      description
-        "Is area ID valid?";
+         Section 5.2.1. TLV 514.";
     }
 
     leaf as {
@@ -302,7 +295,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.";
+         Section 5.2. TLV 512.";
     }
 
     leaf router-id {
@@ -312,7 +305,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 515.";
     }
 
     leaf dr-identifier {
@@ -325,7 +318,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.1.";
+         Section 5.2.1. TLV 515.";
     }
 
     leaf route-type {
@@ -335,7 +328,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.3.1.";
+         Section 5.2.3.1. TLV 264.";
     }
 
     leaf multi-topology-id {
@@ -345,7 +338,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.2.1.";
+         Section 5.2.2.1. TLV 263.";
     }
 
     leaf prefix {
@@ -356,7 +349,7 @@ submodule ietf-bgp-ls-topo-ospf {
       reference
         "RFC 9552: Distribution of Link-State and Traffic
          Engineering Information Using BGP,
-         Section 5.2.3.2.";
+         Section 5.2.3.2. TLV 265.";
     }
   }
 }

--- a/src/yang/ietf-bgp-ls-topo-ospf.yang
+++ b/src/yang/ietf-bgp-ls-topo-ospf.yang
@@ -1,0 +1,362 @@
+submodule ietf-bgp-ls-topo-ospf {
+  yang-version 1.1;
+
+  belongs-to ietf-bgp-lsdb {
+    prefix "bgp-lsdb";
+  }
+
+  import ietf-inet-types { 
+    prefix inet;
+    reference
+      "RFC 9911: Common YANG Data Types.";
+  }
+
+  import ietf-bgp-ls-topo-types {
+    prefix bgp-ls-topo-t;
+    reference
+      "RFC XXXX: BGP Model for Link State Distribution.";
+  }
+
+  import ietf-routing-types { 
+    prefix ietf-rt-t;
+    reference
+      "RFC 8294: Common YANG Data Types for the Routing Area.";
+  }
+
+  import ietf-ospf { 
+    prefix ietf-ospf-t;
+    reference
+      "RFC 9129: YANG Data Model for the OSPF Protocol.";
+  }
+
+  organization
+    "IETF LSVR Working Group";
+  
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/lsvr>
+     WG List:  <lsvr@ietf.org>
+
+     Authors: Mahesh Jethanandani (mjethanandani at gmail.com),
+              Keyur Patel (keyur at arrcus.com)";
+
+  description
+    "This submodule contains groupings for OSPFv2/OSPFv3
+     node and link NLRIs.
+    
+     Copyright (c) 2025 IETF Trust and the persons identified as
+     authors of the code. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC XXXX
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
+
+  revision YYYY-MM-DD {
+    description
+      "Initial Version";
+    reference
+      "RFC XXXX, BGP Model for Link State Distribution.";
+  }
+
+  grouping bgp-ls-ospf-node-common {
+    description
+      "Common fields for OSPFv2 and OSPFv3 node NLRIs.";
+
+    leaf is-as-scoped {
+      type boolean;
+      description
+        "Is area ID valid?";
+    }
+
+    leaf area-id {
+      type ietf-ospf-t:area-id-type;
+      description
+        "Area ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf as {
+      type inet:as-number;
+      description
+        "Autonomous System (AS) number associated with the
+         BGP process originating the NLRI.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+  }
+
+  grouping bgp-ls-ospf-link-common {
+    description
+      "Common fields for OSPFv2 and OSPFv3 link NLRIs.";
+
+    leaf is-as-scoped {
+      type boolean;
+      description
+        "Is area ID valid?";
+    }
+
+    leaf area-id {
+      type ietf-ospf-t:area-id-type;
+      description
+        "Area ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf local-as {
+      type inet:as-number;
+      description
+        "Autonomous System (AS) number associated with the
+         BGP process originating the NLRI.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf local-router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Local Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf local-dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Local Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf remote-as {
+      type inet:as-number;
+      description
+        "Autonomous System (AS) number associated with the
+         BGP process originating the NLRI.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf remote-router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Remote Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf remote-dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Remote Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf local-id {
+      type uint32;
+      description
+        "Local Identifier of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf remote-id {
+      type uint32;
+      description
+        "Remote Identifier of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf local-ipv4-address {
+      type inet:ipv4-address;
+      description
+        "Local IPv4 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf remote-ipv4-address {
+      type inet:ipv4-address;
+      description
+        "Remote IPv4 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf local-ipv6-address {
+      type inet:ipv6-address;
+      description
+        "Local IPv6 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf remote-ipv6-address {
+      type inet:ipv6-address;
+      description
+        "Remote IPv6 address of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.";
+    }
+
+    leaf multi-topology-id {
+      type uint16;
+      description
+        "Multi Topology Identifier (MTID) of a link.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.1.";
+    }
+  }
+
+  grouping bgp-ls-ospf-prefix-common {
+    description
+      "Common fields for OSPFv2 and OSPFv3 prefix NLRIs.";
+
+    leaf is-as-scoped {
+      type boolean;
+      description
+        "Is area ID valid?";
+    }
+
+    leaf as {
+      type inet:as-number;
+      description
+        "Autonomous System (AS) number associated with the
+         BGP process originating the NLRI.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.";
+    }
+
+    leaf router-id {
+      type ietf-rt-t:router-id;
+      description
+        "Router ID.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf dr-identifier {
+      type union {
+        type inet:ipv4-address;
+        type uint32;
+      }
+      description
+        "Designated Router (DR) Identifier.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.1.";
+    }
+
+    leaf route-type {
+      type bgp-ls-topo-t:ospf-route-type;
+      description
+        "OSPF Route type of a prefix.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.3.1.";
+    }
+
+    leaf multi-topology-id {
+      type uint16;
+      description
+        "Multi Topology Identifier (MTID) of a prefix.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.2.1.";
+    }
+
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "IP address prefix (IPv4 or IPv6) advertised in
+         the IGP topology.";
+      reference
+        "RFC 9552: Distribution of Link-State and Traffic
+         Engineering Information Using BGP,
+         Section 5.2.3.2.";
+    }
+  }
+}

--- a/src/yang/ietf-bgp-ls-topo-ospf.yang
+++ b/src/yang/ietf-bgp-ls-topo-ospf.yang
@@ -77,7 +77,8 @@ submodule ietf-bgp-ls-topo-ospf {
     leaf is-as-scoped {
       type boolean;
       description
-        "Is area ID valid?";
+        "When true, the NLRI is AS-scoped and the area-id
+         is not applicable.";
     }
 
     leaf area-id {
@@ -228,7 +229,8 @@ submodule ietf-bgp-ls-topo-ospf {
     leaf is-as-scoped {
       type boolean;
       description
-        "Is area ID valid?";
+        "When true, the NLRI is AS-scoped and the area-id
+         is not applicable.";
     }
 
     leaf area-id {

--- a/src/yang/ietf-bgp-ls-topo-types.yang
+++ b/src/yang/ietf-bgp-ls-topo-types.yang
@@ -233,7 +233,7 @@
        Information Using BGP, Section 3.3.3.";
   }
 
-  typedef adj-sid-format {
+  typedef sid-format {
     type enumeration {
       enum label {
         value 1;
@@ -247,41 +247,7 @@
       }
     }
     description
-      "Format of an adjacency SID value.";
-  }
-
-  typedef pfx-sid-format {
-    type enumeration {
-      enum label {
-        value 1;
-        description
-          "SID represented as an MPLS label value.";
-      }
-      enum index {
-        value 2;
-        description
-          "SID represented as an index value.";
-      }
-    }
-    description
-      "Format of a prefix SID value.";
-  }
-
-  typedef bgp-peer-sid-format {
-    type enumeration {
-      enum label {
-        value 1;
-        description
-          "SID represented as an MPLS label value.";
-      }
-      enum index {
-        value 2;
-        description
-          "SID represented as an index value.";
-      }
-    }
-    description
-      "Format of a BGP peer SID value.";
+      "Format of a SID value (adjacency, prefix, or BGP peer).";
   }
 
   identity bgp-ls-topo-attr-type {
@@ -423,14 +389,6 @@
        Extensions for Segment Routing";
   }
 
-  identity bgp-ls-topo-attr-srgb-isis-flags {
-    base "bgp-ls-topo-attr-type";
-    description
-      "BGP-LS TLV 1034. SRGB ISIS flags";
-    reference
-      "RFC 8667: IS-IS Extensions for Segment Routing";
-  }
-
   identity bgp-ls-topo-attr-srlb {
     base "bgp-ls-topo-attr-type";
     description
@@ -446,7 +404,8 @@
     description
       "BGP-LS TLV 1038. SRv6 Capabilities Flags.";
     reference
-      "SLBgplsTopoSrv6CapFlags";
+      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing over IPv6 (SRv6).";
   }
 
   identity bgp-ls-topo-attr-fad {
@@ -571,7 +530,7 @@
   identity bgp-ls-topo-attr-extended-admin-group {
     base "bgp-ls-topo-attr-type";
     description
-      "BGP-LS TLV 1088. Extended Administrative Group";
+      "BGP-LS TLV 1173. Extended Administrative Group";
     reference
       "RFC 9552: Distribution of Link-State and Traffic
        Engineering Information Using BGP.";
@@ -654,6 +613,15 @@
     description
       "BGP-LS TLV 1097. Envelope that transparently carries optional
        Link Attribute TLVs advertised by a router";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-link-name {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1098. Symbolic name of a link";
     reference
       "RFC 9552: Distribution of Link-State and Traffic
        Engineering Information Using BGP.";

--- a/src/yang/ietf-bgp-ls-topo-types.yang
+++ b/src/yang/ietf-bgp-ls-topo-types.yang
@@ -233,6 +233,57 @@
        Information Using BGP, Section 3.3.3.";
   }
 
+  typedef adj-sid-format {
+    type enumeration {
+      enum label {
+        value 1;
+        description
+          "SID represented as an MPLS label value.";
+      }
+      enum index {
+        value 2;
+        description
+          "SID represented as an index value.";
+      }
+    }
+    description
+      "Format of an adjacency SID value.";
+  }
+
+  typedef pfx-sid-format {
+    type enumeration {
+      enum label {
+        value 1;
+        description
+          "SID represented as an MPLS label value.";
+      }
+      enum index {
+        value 2;
+        description
+          "SID represented as an index value.";
+      }
+    }
+    description
+      "Format of a prefix SID value.";
+  }
+
+  typedef bgp-peer-sid-format {
+    type enumeration {
+      enum label {
+        value 1;
+        description
+          "SID represented as an MPLS label value.";
+      }
+      enum index {
+        value 2;
+        description
+          "SID represented as an index value.";
+      }
+    }
+    description
+      "Format of a BGP peer SID value.";
+  }
+
   identity bgp-ls-topo-attr-type {
     description
       "Base identity for BGP-LS topology attribute type.";

--- a/src/yang/ietf-bgp-ls-topo-types.yang
+++ b/src/yang/ietf-bgp-ls-topo-types.yang
@@ -83,6 +83,16 @@
         description
           "Value of BGP-LS protocol BGP";
       }
+      enum rsvp-te {
+        value 8;
+        description
+          "Value of BGP-LS protocol RSVP-TE";
+      }
+      enum sr {
+        value 9;
+        description
+          "Value of BGP-LS protocol SR";
+      }
     }
     description
       "BGP-LS Protocol";
@@ -221,7 +231,7 @@
     reference
       "RFC 9552: Distribution of Link-State and Traffic Engineering
        Information Using BGP, Section 3.3.3.";
-}
+  }
 
   identity bgp-ls-topo-attr-type {
     description
@@ -232,6 +242,15 @@
     description
       "Base identity for BGP-LS topology Flexible Algorithm
        Definition (FAD) attribute type.";
+  }
+
+  identity bgp-ls-topo-attr-link-local-remote-identifiers {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 258. Link local and remote identifiers";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+      Engineering Information Using BGP.";
   }
 
   identity bgp-ls-topo-attr-multi-topology-id {
@@ -247,6 +266,15 @@
     base "bgp-ls-topo-attr-type";
     description
       "BGP-LS TLV 266. Node Maximum SID Depth";
+    reference
+      "RFC 8814: Signaling Maximum SID Depth (MSD) Using the
+      Border Gateway Protocol - Link State";
+  }
+
+  identity bgp-ls-topo-attr-link-msd {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 267. Link Maximum SID Depth";
     reference
       "RFC 8814: Signaling Maximum SID Depth (MSD) Using the
       Border Gateway Protocol - Link State";
@@ -307,6 +335,24 @@
       Information Using BGP.";
   }
 
+  identity bgp-ls-topo-attr-remote-ipv4-routerid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1030. Remote Router-ID used by the IGP";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic Engineering
+      Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-remote-ipv6-routerid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1031. Remote Router-ID used by the IGP";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic Engineering
+      Information Using BGP.";
+  }
+
   identity bgp-ls-topo-attr-sr-capabilities {
     base "bgp-ls-topo-attr-type";
     description
@@ -326,6 +372,14 @@
        Extensions for Segment Routing";
   }
 
+  identity bgp-ls-topo-attr-srgb-isis-flags {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1034. SRGB ISIS flags";
+    reference
+      "RFC 8667: IS-IS Extensions for Segment Routing";
+  }
+
   identity bgp-ls-topo-attr-srlb {
     base "bgp-ls-topo-attr-type";
     description
@@ -334,6 +388,14 @@
     reference
       "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
        Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-srv6-cap-flags {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1038. SRv6 Capabilities Flags.";
+    reference
+      "SLBgplsTopoSrv6CapFlags";
   }
 
   identity bgp-ls-topo-attr-fad {
@@ -453,6 +515,382 @@
     reference
       "RFC TBD: BGP-LS extensions for Flexible Algorithms Reverse
        Affinity Constraint";
+  }
+
+  identity bgp-ls-topo-attr-extended-admin-group {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1088. Extended Administrative Group";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-maximum-link-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1089. Maximum link bandwidth";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-maximum-reservable-link-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1090. Maximum reservable link bandwidth";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-unreserved-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1091. Unreserved bandwidth";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-te-default-metric {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1092. Traffic Engineering default metric";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-link-protection-type {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1093. Link protection type";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-mpls-protocol-mask {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1094. MPLS protocol mask";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-igp-metric {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1095. IGP metric";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-srlg {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1096. Shared Risk Link Group (SRLG)";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-opaque-link {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1097. Envelope that transparently carries optional
+       Link Attribute TLVs advertised by a router";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-adjacency-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1099. Adjacency Segment Identifier (SID)";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-lan-adjacency-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1100. LAN adjacency Segment Identifier (SID)";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-bgp-peer-node-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1101. BGP peer node Segment Identifier (SID)";
+    reference
+      "RFC 9086: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-bgp-peer-adj-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1102. BGP peer adjacency Segment Identifier
+       (SID)";
+    reference
+      "RFC 9086: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-bgp-peer-set-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1103. BGP peer set Segment Identifier (SID)";
+    reference
+      "RFC 9086: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-srv6-end-x-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1106. SRv6 End.X SID";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
+  }
+
+  identity bgp-ls-topo-attr-srv6-isis-lan-end-x-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1107. SRv6 ISIS LAN End.X SID";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
+  }
+
+  identity bgp-ls-topo-attr-srv6-ospf-lan-end-x-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1108. SRv6 OSPF LAN End.X SID";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-link-delay {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1114. Unidirectional link delay";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-min-max-unidir-link-delay {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1115. Min/max unidirectional link delay";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-delay-variation {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1116. Unidirectional delay variation";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-link-loss {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1117. Unidirectional link loss";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-residual-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1118. Unidirectional residual bandwidth";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-available-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1119. Unidirectional available bandwidth";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-unidir-utilized-bw {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1120. Unidirectional utilized bandwidth";
+    reference
+      "RFC 8571: Link State (BGP-LS) Advertisement of IGP Traffic
+       Engineering Performance Metric Extensions.";
+  }
+
+  identity bgp-ls-topo-attr-asla {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1122. Application-Specific Link Attributes";
+    reference
+      "RFC 9294: Application-Specific Link Attributes Advertisement
+       Using the Border Gateway Protocol - Link State (BGP-LS).";
+  }
+
+  identity bgp-ls-topo-attr-igp-flags {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1152. Flags and bits assigned to a prefix";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-igp-route-tag {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1153. Tags of a prefix";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-ext-igp-route-tag {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1154. Extended route tags of a prefix";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-prefix-metric {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1155. Metric of a prefix";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-ospf-forwarding-address {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1156. Forwarding address of a prefix";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-opaque-prefix {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1157. Envelope that transparently carries optional
+       Prefix Attribute TLVs advertised by a router";
+    reference
+      "RFC 9552: Distribution of Link-State and Traffic
+       Engineering Information Using BGP.";
+  }
+
+  identity bgp-ls-topo-attr-prefix-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1158. Prefix Segment Identifiers (SIDs)";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-prefix-range {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1159. Range of prefix-to-SID mapping";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-srv6-locator {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1162. SRv6 locator information associated with a
+       prefix";
+    reference
+      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing over IPv6 (SRv6)";
+  }
+
+  identity bgp-ls-topo-attr-prefix-attribute-flags {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1170. Prefix attribute flags";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-prefix-src-router-id {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1171. Source route identifier of a prefix";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-l2-bundle-member {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1172. L2 bundle member";
+    reference
+      "RFC 9085: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Segment Routing";
+  }
+
+  identity bgp-ls-topo-attr-fa-prefix-metric {
+    base "bgp-ls-topo-attr-type";
+    description
+      "BGP-LS TLV 1044. Flexible Algorithm prefix metric";
+    reference
+      "RFC 9351: Border Gateway Protocol - Link State (BGP-LS)
+       Extensions for Flexible Algorithm Advertisement";
+  }
+
+  identity bgp-ls-topo-attr-srv6-endpoint-behavior {
+    base "bgp-ls-topo-attr-type";
+    description
+      "SRv6 endpoint behavior";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
+  }
+
+  identity bgp-ls-topo-attr-srv6-bgp-peer-node-sid {
+    base "bgp-ls-topo-attr-type";
+    description
+      "SRv6 BGP peer node SID";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
+  }
+
+  identity bgp-ls-topo-attr-srv6-sid-structure {
+    base "bgp-ls-topo-attr-type";
+    description
+      "SRv6 SID structure";
+    reference
+      "RFC 9514: SRv6 BGP-LS extensions.";
   }
 
   identity bgp-ls-topo-attr-unknowns {

--- a/src/yang/ietf-bgp-ls.yang
+++ b/src/yang/ietf-bgp-ls.yang
@@ -480,8 +480,7 @@ module ietf-bgp-ls {
 
   augment "/rt:routing/rt:control-plane-protocols" +
           "/rt:control-plane-protocol/bgp:bgp/bgp:neighbors" +
-      "/bgp:neighbor/bgp:afi-safis/bgp:afi-safi" +
-      "/link-state-spf" {
+          "/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/link-state-spf" {
     description
       "Augmentation of the BGP neighbor to add BGL-LS.";
     uses bgp-neighbor-ls-common;

--- a/src/yang/ietf-bgp-ls.yang
+++ b/src/yang/ietf-bgp-ls.yang
@@ -480,7 +480,8 @@ module ietf-bgp-ls {
 
   augment "/rt:routing/rt:control-plane-protocols" +
           "/rt:control-plane-protocol/bgp:bgp/bgp:neighbors" +
-          "/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/link-state-spf" {
+      "/bgp:neighbor/bgp:afi-safis/bgp:afi-safi" +
+      "/link-state-spf" {
     description
       "Augmentation of the BGP neighbor to add BGL-LS.";
     uses bgp-neighbor-ls-common;

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -1041,10 +1041,10 @@ module ietf-bgp-lsdb {
                     }
                     description
                       "This container describes the unknown
-                       attributes.
+                       attributes.";
                     reference
-                      "RFC 9552: Distribution of Link-State and Traffic
-                       Engineering Information Using BGP.";
+                      "RFC 9552: Distribution of Link-State and
+                       Traffic Engineering Information Using BGP.";
 
                     uses bgp-ls-topo-unknown-attr;
                   }

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -266,7 +266,9 @@ module ietf-bgp-lsdb {
               leaf local-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Local IPv6 address of a link.";
+                  "Local IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -276,7 +278,9 @@ module ietf-bgp-lsdb {
               leaf remote-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Remote IPv6 address of a link.";
+                  "Remote IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -380,7 +384,9 @@ module ietf-bgp-lsdb {
               leaf local-ipv4-address {
                 type inet:ipv4-address;
                 description
-                  "Local IPv4 address of a link.";
+                  "Local IPv4 address of a link. Use 0.0.0.0 as a
+                   sentinel value when this address is not present
+                   (e.g., for unnumbered or IPv6-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -390,7 +396,9 @@ module ietf-bgp-lsdb {
               leaf remote-ipv4-address {
                 type inet:ipv4-address;
                 description
-                  "Remote IPv4 address of a link.";
+                  "Remote IPv4 address of a link. Use 0.0.0.0 as a
+                   sentinel value when this address is not present
+                   (e.g., for unnumbered or IPv6-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -400,7 +408,9 @@ module ietf-bgp-lsdb {
               leaf local-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Local IPv6 address of a link.";
+                  "Local IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -410,7 +420,9 @@ module ietf-bgp-lsdb {
               leaf remote-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Remote IPv6 address of a link.";
+                  "Remote IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
@@ -498,7 +510,9 @@ module ietf-bgp-lsdb {
               leaf local-ipv4-address {
                 type inet:ipv4-address;
                 description
-                  "Local IPv4 address of a link.";
+                  "Local IPv4 address of a link. Use 0.0.0.0 as a
+                   sentinel value when this address is not present
+                   (e.g., for unnumbered or IPv6-only links).";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
                    Segments, Section 5.2. TLV 259.";
@@ -507,7 +521,9 @@ module ietf-bgp-lsdb {
               leaf remote-ipv4-address {
                 type inet:ipv4-address;
                 description
-                  "Remote IPv4 address of a link.";
+                  "Remote IPv4 address of a link. Use 0.0.0.0 as a
+                   sentinel value when this address is not present
+                   (e.g., for unnumbered or IPv6-only links).";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
                    Segments, Section 5.2. TLV 260.";
@@ -516,7 +532,9 @@ module ietf-bgp-lsdb {
               leaf local-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Local IPv6 address of a link.";
+                  "Local IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
                    Segments, Section 5.2. TLV 261.";
@@ -525,7 +543,9 @@ module ietf-bgp-lsdb {
               leaf remote-ipv6-address {
                 type inet:ipv6-address;
                 description
-                  "Remote IPv6 address of a link.";
+                  "Remote IPv6 address of a link. Use :: as a sentinel
+                   value when this address is not present (e.g., for
+                   unnumbered or IPv4-only links).";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
                    Segments, Section 5.2. TLV 262.";

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -132,6 +132,7 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for nodes";
 
             list ospf-node {
+              when "../../protocol = 'ospfv2'";
               key "is-as-scoped area-id router-id dr-identifier as";
               description
                 "List of OSPFv2 nodes";
@@ -142,6 +143,7 @@ module ietf-bgp-lsdb {
             }
 
             list ospfv3-node {
+              when "../../protocol = 'ospfv3'";
               key "is-as-scoped area-id router-id dr-identifier as";
               description
                 "List of OSPFv3 nodes";
@@ -152,6 +154,8 @@ module ietf-bgp-lsdb {
             }
 
             list isis-node {
+              when "../../protocol = 'isis-l1' or " +
+                   "../../protocol = 'isis-l2'";
               key "system-id psn-id as";
               description
                 "List of IS-IS nodes";
@@ -196,6 +200,7 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for links";
 
             list ospf-link {
+              when "../../protocol = 'ospfv2'";
               key "area-id as local-router-id " +
                   "local-dr-identifier " +
                   "remote-router-id remote-dr-identifier " +
@@ -231,6 +236,7 @@ module ietf-bgp-lsdb {
             }
 
             list ospfv3-link {
+              when "../../protocol = 'ospfv3'";
               key "area-id as local-router-id " +
                   "local-dr-identifier " +
                   "remote-router-id remote-dr-identifier " +
@@ -291,6 +297,8 @@ module ietf-bgp-lsdb {
             }
 
             list isis-link {
+              when "../../protocol = 'isis-l1' or " +
+                   "../../protocol = 'isis-l2'";
               key "local-system-id local-psn-id local-as " +
                   "remote-system-id remote-psn-id remote-as " +
                   "local-id remote-id local-ipv4-address " +
@@ -443,6 +451,7 @@ module ietf-bgp-lsdb {
             }
 
             list bgp-link {
+              when "../../protocol = 'bgp'";
               key "local-as local-router-id remote-as " +
                   "remote-router-id local-id remote-id " +
                   "local-ipv4-address remote-ipv4-address " +
@@ -590,8 +599,9 @@ module ietf-bgp-lsdb {
                          "'bgp-ls-topo-t:" +
                          "bgp-ls-topo-attr-bgp-peer-set-sid')" {
                       description
-                        "Only include the bgp-peer-sids container when the
-                         type is bgp-ls-topo-attr-bgp-peer-node-sid,
+                        "Only include the bgp-peer-sids container
+                         when the type is
+                         bgp-ls-topo-attr-bgp-peer-node-sid,
                          bgp-ls-topo-attr-bgp-peer-adj-sid, or
                          bgp-ls-topo-attr-bgp-peer-set-sid";
                     }
@@ -600,8 +610,8 @@ module ietf-bgp-lsdb {
                        Identifiers (SIDs) of a link";
                     reference
                       "RFC 9086: Border Gateway Protocol - Link State
-                       (BGP-LS) Extensions for Segment Routing. TLV 1101,
-                       TLV 1102 and TLV 1103";
+                       (BGP-LS) Extensions for Segment Routing.
+                       TLV 1101, TLV 1102 and TLV 1103";
 
                     list bgp-peer-sid {
                       key "label-index format";
@@ -646,6 +656,7 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for prefixes";
 
             list ospf-prefix {
+              when "../../protocol = 'ospfv2'";
               key "is-as-scoped area-id as " +
                   "router-id dr-identifier " +
                   "multi-topology-id route-type prefix";
@@ -679,6 +690,7 @@ module ietf-bgp-lsdb {
             }
 
             list ospfv3-prefix {
+              when "../../protocol = 'ospfv3'";
               key "is-as-scoped area-id as " +
                   "router-id dr-identifier " +
                   "multi-topology-id route-type prefix";
@@ -712,6 +724,8 @@ module ietf-bgp-lsdb {
             }
 
             list isis-prefix {
+              when "../../protocol = 'isis-l1' or " +
+                   "../../protocol = 'isis-l2'";
               key "system-id psn-id as multi-topology-id prefix";
               description
                 "List of ISIS prefix types";
@@ -777,6 +791,7 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for SRv6 SIDs";
 
             list ospfv3-srv6-sid {
+              when "../../protocol = 'ospfv3'";
               key "is-as-scoped area-id router-id " +
                   "dr-identifier as sid multi-topology-id";
               description
@@ -857,6 +872,8 @@ module ietf-bgp-lsdb {
             }
 
             list isis-srv6-sid {
+              when "../../protocol = 'isis-l1' or " +
+                   "../../protocol = 'isis-l2'";
               key "system-id psn-id as sid multi-topology-id";
               description
                 "List of ISIS SRv6 SID types";
@@ -915,6 +932,7 @@ module ietf-bgp-lsdb {
             }
 
             list bgp-srv6-sid {
+              when "../../protocol = 'bgp'";
               key "router-id as sid multi-topology-id";
               description
                 "List of BGP SRv6 SID types";
@@ -980,16 +998,17 @@ module ietf-bgp-lsdb {
                          "'bgp-ls-topo-t:" +
                          "bgp-ls-topo-attr-srv6-endpoint-behavior')" {
                       description
-                        "Only include the srv6-endpoint-behavior container
-                         when the type is
+                        "Only include the srv6-endpoint-behavior
+                         container when the type is
                          bgp-ls-topo-attr-srv6-endpoint-behavior";
                     }
                     description
-                      "This container contains the SRv6 endpoint behavior.";
+                      "This container contains the SRv6 endpoint
+                       behavior.";
                     reference
-                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
-                       Extensions for Segment Routing over IPv6 (SRv6).
-                       SRv6 endpoint behavior. TLV 1250.";
+                      "RFC 9514: Border Gateway Protocol - Link State
+                       (BGP-LS) Extensions for Segment Routing over
+                       IPv6 (SRv6). SRv6 endpoint behavior. TLV 1250.";
 
                     uses bgp-ls-topo-srv6-endpoint-behavior-attr;
                   }
@@ -1006,9 +1025,9 @@ module ietf-bgp-lsdb {
                     description
                       "This container defines the SRv6 SID structure.";
                     reference
-                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
-                       Extensions for Segment Routing over IPv6 (SRv6).
-                       SRv6 SID structure. TLV 1252.";
+                      "RFC 9514: Border Gateway Protocol - Link State
+                       (BGP-LS) Extensions for Segment Routing over
+                       IPv6 (SRv6). SRv6 SID structure. TLV 1252.";
 
                     uses bgp-ls-topo-srv6-sid-struct-attr;
                   }
@@ -1017,11 +1036,12 @@ module ietf-bgp-lsdb {
                     when "derived-from-or-self(../type, " +
                         "'bgp-ls-topo-t:bgp-ls-topo-attr-unknowns')" {
                     description
-                        "Only include the unknowns container when the type is
-                        bgp-ls-topo-attr-unknowns";
+                        "Only include the unknowns container when the
+                         type is bgp-ls-topo-attr-unknowns";
                     }
                     description
-                      "This container describes the unknown attributes.";
+                      "This container describes the unknown
+                       attributes.
                     reference
                       "RFC 9552: Distribution of Link-State and Traffic
                        Engineering Information Using BGP.";
@@ -1034,23 +1054,25 @@ module ietf-bgp-lsdb {
                          "'bgp-ls-topo-t:" +
                          "bgp-ls-topo-attr-srv6-bgp-peer-node-sid')" {
                       description
-                        "Only include the srv6-bgp-peer-node-sid container
-                         when the type is
+                        "Only include the srv6-bgp-peer-node-sid
+                         container when the type is
                          bgp-ls-topo-attr-srv6-bgp-peer-node-sid";
                     }
                     description
-                      "This container contains the SRv6 BGP peer node SID.";
+                      "This container contains the SRv6 BGP peer
+                       node SID.";
                     reference
-                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
-                       Extensions for Segment Routing over IPv6 (SRv6).
-                       SRv6 BGP peer node SID. TLV 1251.";
+                      "RFC 9514: Border Gateway Protocol - Link State
+                       (BGP-LS) Extensions for Segment Routing over
+                       IPv6 (SRv6). SRv6 BGP peer node SID. TLV 1251.";
 
                     leaf flags {
                       type binary {
                         length "1";
                       }
                       description
-                        "Flags associated with the SRv6 BGP peer node SID";
+                        "Flags associated with the SRv6 BGP peer
+                         node SID";
                     }
 
                     leaf weight {

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -33,6 +33,12 @@ module ietf-bgp-lsdb {
       "RFC 9130: YANG Data Model for IS-IS Protocol.";
   }
 
+  import ietf-ospf {
+    prefix ietf-ospf-t;
+    reference
+      "RFC 9129: YANG Data Model for the OSPF Protocol.";
+  }
+
   include ietf-bgp-ls-topo-attr;
   include ietf-bgp-ls-topo-ospf;
 
@@ -535,7 +541,83 @@ module ietf-bgp-lsdb {
                    Section 5.2.2.1. TLV 263.";
               }
 
-              uses bgp-ls-topo-bgp-link-attr;
+              container link-attributes {
+                description
+                  "Enclosing container for link attributes list";
+
+                list link-attribute {
+                  key "type";
+
+                  description
+                    "List of link attribute types.";
+
+                  leaf type {
+                    type identityref {
+                      base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+                    }
+                    description
+                      "The type of link attribute";
+                  }
+
+                  container bgp-peer-sids {
+                    when "derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-bgp-peer-node-sid')" +
+                         " or derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-bgp-peer-adj-sid')" +
+                         " or derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-bgp-peer-set-sid')" {
+                      description
+                        "Only include the bgp-peer-sids container when the
+                         type is bgp-ls-topo-attr-bgp-peer-node-sid,
+                         bgp-ls-topo-attr-bgp-peer-adj-sid, or
+                         bgp-ls-topo-attr-bgp-peer-set-sid";
+                    }
+                    description
+                      "This container contains the BGP peer Segment
+                       Identifiers (SIDs) of a link";
+                    reference
+                      "RFC 9086: Border Gateway Protocol - Link State
+                       (BGP-LS) Extensions for Segment Routing. TLV 1101,
+                       TLV 1102 and TLV 1103";
+
+                    list bgp-peer-sid {
+                      key "label-index format";
+
+                      description
+                        "List of BGP peer SID";
+
+                      leaf label-index {
+                        type uint32;
+                        description
+                          "Label or index";
+                      }
+
+                      leaf format {
+                        type bgp-ls-topo-t:sid-format;
+                        description
+                          "Format of the SID";
+                      }
+
+                      leaf flags {
+                        type binary {
+                          length "1";
+                        }
+                        description
+                          "Flags associated with the BGP peer SID";
+                      }
+
+                      leaf weight {
+                        type uint8;
+                        description
+                          "Weight used for load balancing purposes";
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
 
@@ -665,9 +747,9 @@ module ietf-bgp-lsdb {
                    Engineering Information Using BGP,
                    Section 5.2.3.2. TLV 265.";
               }
-            }
 
-            uses bgp-ls-topo-prefix-attr;
+              uses bgp-ls-topo-prefix-attr;
+            }
           }
 
           container srv6-sids {
@@ -692,7 +774,7 @@ module ietf-bgp-lsdb {
               }
 
               leaf area-id {
-                type inet:ipv4-address;
+                type ietf-ospf-t:area-id-type;
                 description
                   "OSPF area identifier.";
                 reference
@@ -855,7 +937,122 @@ module ietf-bgp-lsdb {
                    Section 5.2.2.1. TLV 263.";
               }
 
-              uses bgp-ls-topo-bgp-srv6-sid-attr;
+              container srv6-sid-attributes {
+                description
+                  "Enclosing container for SRv6 SID attributes list";
+
+                list srv6-sid-attribute {
+                  key "type";
+
+                  description
+                    "List of SRv6 SID attribute types.";
+
+                  leaf type {
+                    type identityref {
+                      base bgp-ls-topo-t:bgp-ls-topo-attr-type;
+                    }
+                    description
+                      "The type of SRv6 SID attribute";
+                  }
+
+                  container srv6-endpoint-behavior {
+                    when "derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-srv6-endpoint-behavior')" {
+                      description
+                        "Only include the srv6-endpoint-behavior container
+                         when the type is
+                         bgp-ls-topo-attr-srv6-endpoint-behavior";
+                    }
+                    description
+                      "This container contains the SRv6 endpoint behavior.";
+                    reference
+                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+                       Extensions for Segment Routing over IPv6 (SRv6).
+                       SRv6 endpoint behavior. TLV 1250.";
+
+                    uses bgp-ls-topo-srv6-endpoint-behavior-attr;
+                  }
+
+                  container srv6-sid-structure {
+                    when "derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-srv6-sid-structure')" {
+                      description
+                        "Only include the srv6-sid-structure container
+                         when the type is
+                         bgp-ls-topo-attr-srv6-sid-structure";
+                    }
+                    description
+                      "This container defines the SRv6 SID structure.";
+                    reference
+                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+                       Extensions for Segment Routing over IPv6 (SRv6).
+                       SRv6 SID structure. TLV 1252.";
+
+                    uses bgp-ls-topo-srv6-sid-struct-attr;
+                  }
+
+                  container unknowns {
+                    when "derived-from-or-self(../type, " +
+                        "'bgp-ls-topo-t:bgp-ls-topo-attr-unknowns')" {
+                    description
+                        "Only include the unknowns container when the type is
+                        bgp-ls-topo-attr-unknowns";
+                    }
+                    description
+                      "This container describes the unknown attributes.";
+                    reference
+                      "RFC 9552: Distribution of Link-State and Traffic
+                       Engineering Information Using BGP.";
+
+                    uses bgp-ls-topo-unknown-attr;
+                  }
+
+                  container srv6-bgp-peer-node-sid {
+                    when "derived-from-or-self(../type, " +
+                         "'bgp-ls-topo-t:" +
+                         "bgp-ls-topo-attr-srv6-bgp-peer-node-sid')" {
+                      description
+                        "Only include the srv6-bgp-peer-node-sid container
+                         when the type is
+                         bgp-ls-topo-attr-srv6-bgp-peer-node-sid";
+                    }
+                    description
+                      "This container contains the SRv6 BGP peer node SID.";
+                    reference
+                      "RFC 9514: Border Gateway Protocol - Link State (BGP-LS)
+                       Extensions for Segment Routing over IPv6 (SRv6).
+                       SRv6 BGP peer node SID. TLV 1251.";
+
+                    leaf flags {
+                      type binary {
+                        length "1";
+                      }
+                      description
+                        "Flags associated with the SRv6 BGP peer node SID";
+                    }
+
+                    leaf weight {
+                      type uint8;
+                      description
+                        "Weight used for load balancing purposes";
+                    }
+
+                    leaf peer-as {
+                      type inet:as-number;
+                      description
+                        "Autonomous system of peer";
+                    }
+
+                    leaf peer-bgp-id {
+                      type ietf-rt-t:router-id;
+                      description
+                        "BGP Router ID of peer";
+                    }
+                  }
+                }
+              }
             }
           }
 

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -195,12 +195,32 @@ module ietf-bgp-lsdb {
                   "remote-router-id remote-dr-identifier " +
                   "local-id remote-id " +
                   "local-ipv4-address remote-ipv4-address " +
-                  "local-ipv6-address remote-ipv6-address " +
                   "multi-topology-id";
               description
                 "List of OSPFv2 link types";
 
               uses bgp-ls-ospf-link-common;
+
+              leaf local-dr-identifier {
+                type inet:ipv4-address;
+                description
+                  "Local Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
+              leaf remote-dr-identifier {
+                type inet:ipv4-address;
+                description
+                  "Remote Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
               uses bgp-ls-topo-igp-link-attr;
             }
 
@@ -216,6 +236,47 @@ module ietf-bgp-lsdb {
                 "List of OSPFv3 link types";
 
               uses bgp-ls-ospf-link-common;
+
+              leaf local-dr-identifier {
+                type uint32;
+                description
+                  "Local Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
+              leaf remote-dr-identifier {
+                type uint32;
+                description
+                  "Remote Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
+              leaf local-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Local IPv6 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2. TLV 261.";
+              }
+
+              leaf remote-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Remote IPv6 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2. TLV 262.";
+              }
+
               uses bgp-ls-topo-igp-link-attr;
             }
 
@@ -490,6 +551,28 @@ module ietf-bgp-lsdb {
                 "List of OSPFv2 prefix types";
 
               uses bgp-ls-ospf-prefix-common;
+
+              leaf dr-identifier {
+                type inet:ipv4-address;
+                description
+                  "Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
+              leaf prefix {
+                type inet:ipv4-prefix;
+                description
+                  "IPv4 address prefix advertised in the
+                   OSPFv2 topology.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.3.2. TLV 265.";
+              }
+
               uses bgp-ls-topo-prefix-attr;
             }
 
@@ -501,6 +584,28 @@ module ietf-bgp-lsdb {
                 "List of OSPFv3 prefix types";
 
               uses bgp-ls-ospf-prefix-common;
+
+              leaf dr-identifier {
+                type uint32;
+                description
+                  "Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 515.";
+              }
+
+              leaf prefix {
+                type inet:ip-prefix;
+                description
+                  "IP address prefix (IPv4 or IPv6) advertised in
+                   the OSPFv3 topology.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.3.2. TLV 265.";
+              }
+
               uses bgp-ls-topo-prefix-attr;
             }
 

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -33,13 +33,8 @@ module ietf-bgp-lsdb {
       "RFC 9130: YANG Data Model for IS-IS Protocol.";
   }
 
-  import ietf-ospf {
-    prefix ietf-ospf-t;
-    reference
-      "RFC 9129: YANG Data Model for the OSPF Protocol.";
-  }
-
   include ietf-bgp-ls-topo-attr;
+  include ietf-bgp-ls-topo-ospf;
 
   organization
     "IETF LSVR Working Group";
@@ -135,52 +130,17 @@ module ietf-bgp-lsdb {
               description
                 "List of node types";
 
-              leaf is-as-scoped {
-                type boolean;
-                description
-                  "Is area ID valid?";
-              }
+              uses bgp-ls-ospf-node-common;
 
-              leaf area-id {
-                type ietf-ospf-t:area-id-type;
-                description
-                  "Area ID.";
-                reference
-                  "RFC 9552: Distribution of Link-State and
-                   Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
-              }
+              uses bgp-ls-topo-node-attr;
+            }
 
-              leaf router-id {
-                type ietf-rt-t:router-id;
-                description
-                  "Router ID.";
-                reference
-                  "RFC 9552: Distribution of Link-State and
-                   Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
-              }
+            list ospfv3-node {
+              key "is-as-scoped area-id router-id dr-identifier as";
+              description
+                "List of node types";
 
-              leaf dr-identifier {
-                type inet:ipv4-address;
-                description
-                  "Designated Router (DR) Identifier.";
-                reference
-                  "RFC 9552: Distribution of Link-State and
-                   Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
-              }
-
-              leaf as {
-                type inet:as-number;
-                description
-                  "Autonomous System (AS) number associated with the
-                   BGP process originating the NLRI.";
-                reference
-                  "RFC 9552: Distribution of Link-State and
-                   Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
-              }
+              uses bgp-ls-ospf-node-common;
 
               uses bgp-ls-topo-node-attr;
             }
@@ -225,10 +185,555 @@ module ietf-bgp-lsdb {
             }
           }
 
+          container links {
+            description 
+              "BGP-LS topology entries for links";
+
+            list ospf-link {
+              key "is-as-scoped area-id local-as local-router-id " +
+                  "local-dr-identifier remote-as " +
+                  "remote-router-id remote-dr-identifier " +
+                  "local-id remote-id " +
+                  "local-ipv4-address remote-ipv4-address " +
+                  "local-ipv6-address remote-ipv6-address " +
+                  "multi-topology-id";
+              description
+                "List of OSPFv2 link types";
+
+              uses bgp-ls-ospf-link-common;
+              uses bgp-ls-topo-igp-link-attr;
+            }
+
+            list ospfv3-link {
+              key "is-as-scoped area-id local-as local-router-id " +
+                  "local-dr-identifier remote-as " +
+                  "remote-router-id remote-dr-identifier " +
+                  "local-id remote-id " +
+                  "local-ipv4-address remote-ipv4-address " +
+                  "local-ipv6-address remote-ipv6-address " +
+                  "multi-topology-id";
+              description
+                "List of OSPFv3 link types";
+
+              uses bgp-ls-ospf-link-common;
+              uses bgp-ls-topo-igp-link-attr;
+            }
+
+            list isis-link {
+              key "local-system-id local-psn-id local-as " +
+                  "remote-system-id remote-psn-id remote-as " +
+                  "local-id remote-id local-ipv4-address " +
+                  "remote-ipv4-address local-ipv6-address " +
+                  "remote-ipv6-address multi-topology-id";
+              description
+                "List of ISIS link types";
+
+              leaf local-system-id {
+                type ietf-isis-t:system-id;
+                description
+                  "Local System ID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf local-psn-id {
+                type uint8;
+                description
+                  "Local Pseudo Node Identifier (PSN ID).";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf local-as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number associated with the
+                   BGP process originating the NLRI.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf remote-system-id {
+                type ietf-isis-t:system-id;
+                description
+                  "Remote System ID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf remote-psn-id {
+                type uint8;
+                description
+                  "Remote Pseudo Node Identifier (PSN ID).";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf remote-as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number associated with the
+                   BGP process originating the NLRI.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf local-id {
+                type uint32;
+                description
+                  "Local Identifier of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf remote-id {
+                type uint32;
+                description
+                  "Remote Identifier of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf local-ipv4-address {
+                type inet:ipv4-address;
+                description
+                  "Local IPv4 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf remote-ipv4-address {
+                type inet:ipv4-address;
+                description
+                  "Remote IPv4 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf local-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Local IPv6 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf remote-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Remote IPv6 address of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              uses bgp-ls-topo-igp-link-attr;
+            }
+
+            list bgp-link {
+              key "local-as local-router-id remote-as " +
+                  "remote-router-id local-id remote-id " +
+                  "local-ipv4-address remote-ipv4-address " +
+                  "local-ipv6-address remote-ipv6-address " +
+                  "multi-topology-id";
+              description
+                "List of BGP link types";
+
+              leaf local-as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number or AS
+                   Confederation Identifier.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf local-router-id {
+                type ietf-rt-t:router-id;
+                description
+                  "Local BGP Router ID.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf remote-as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number or AS
+                   Confederation Identifier.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf remote-router-id {
+                type ietf-rt-t:router-id;
+                description
+                  "Remote BGP Router ID.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf local-id {
+                type uint32;
+                description
+                  "Local Identifier of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.3.";
+              }
+
+              leaf remote-id {
+                type uint32;
+                description
+                  "Remote Identifier of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.3.";
+              }
+
+              leaf local-ipv4-address {
+                type inet:ipv4-address;
+                description
+                  "Local IPv4 address of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.2.";
+              }
+
+              leaf remote-ipv4-address {
+                type inet:ipv4-address;
+                description
+                  "Remote IPv4 address of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.2.";
+              }
+
+              leaf local-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Local IPv6 address of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.2.";
+              }
+
+              leaf remote-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "Remote IPv6 address of a link.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 5.2.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a link.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              uses bgp-ls-topo-bgp-link-attr;
+            }
+          }
+
+          container prefixes {
+            description
+              "BGP-LS topology entries for prefixes";
+
+            list ospf-prefix {
+              key "is-as-scoped as router-id dr-identifier " +
+                  "multi-topology-id route-type prefix";
+              description
+                "List of OSPFv2 prefix types";
+
+              uses bgp-ls-ospf-prefix-common;
+              uses bgp-ls-topo-prefix-attr;
+            }
+
+            list ospfv3-prefix {
+              key "is-as-scoped as router-id dr-identifier " +
+                  "multi-topology-id route-type prefix";
+              description
+                "List of OSPFv3 prefix types";
+
+              uses bgp-ls-ospf-prefix-common;
+              uses bgp-ls-topo-prefix-attr;
+            }
+
+            list isis-prefix {
+              key "system-id psn-id as multi-topology-id prefix";
+              description
+                "List of ISIS prefix types";
+
+              leaf system-id {
+                type ietf-isis-t:system-id;
+                description
+                  "System ID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf psn-id {
+                type uint8;
+                description
+                  "Pseudo Node Identifier (PSN ID).";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number associated with the
+                   BGP process originating the NLRI.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a prefix.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              leaf prefix {
+                type inet:ip-prefix;
+                description
+                  "IP address prefix (IPv4 or IPv6) advertised in
+                   the IGP topology.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.3.2.";
+              }
+            }
+
+            uses bgp-ls-topo-prefix-attr;
+          }
+
+          container srv6-sids {
+            description
+              "BGP-LS topology entries for SRv6 SIDs";
+
+            list ospf-srv6-sid {
+              key "router-id dr-identifier as sid multi-topology-id";
+              description
+                "List of OSPF SRv6 SID types";
+
+              leaf router-id {
+                type ietf-rt-t:router-id;
+                description
+                  "Router ID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf dr-identifier {
+                type union {
+                  type inet:ipv4-address;
+                  type uint32;
+                }
+                description
+                  "Designated Router (DR) Identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number associated with the
+                   BGP process originating the NLRI.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.";
+              }
+
+              leaf sid {
+                type inet:ipv6-prefix;
+                description
+                  "SRv6 SID.";
+                reference
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a SRv6 SID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              uses bgp-ls-topo-srv6-sid-attr;
+            }
+
+            list isis-srv6-sid {
+              key "system-id psn-id as sid multi-topology-id";
+              description
+                "List of ISIS SRv6 SID types";
+
+              leaf system-id {
+                type ietf-isis-t:system-id;
+                description
+                  "System ID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf psn-id {
+                type uint8;
+                description
+                  "Pseudo Node Identifier (PSN ID).";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number associated with the
+                   BGP process originating the NLRI.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.";
+              }
+
+              leaf sid {
+                type inet:ipv6-prefix;
+                description
+                  "SRv6 SID.";
+                reference
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a SRv6 SID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              uses bgp-ls-topo-srv6-sid-attr;
+            }
+
+            list bgp-srv6-sid {
+              key "router-id as sid multi-topology-id";
+              description
+                "List of BGP SRv6 SID types";
+
+              leaf router-id {
+                type ietf-rt-t:router-id;
+                description
+                  "BGP Router ID.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf as {
+                type inet:as-number;
+                description
+                  "Autonomous System (AS) number or AS
+                   Confederation Identifier.";
+                reference
+                  "RFC 9086: BGP-LS Extensions for BGP Peering
+                   Segments, Section 4.2.";
+              }
+
+              leaf sid {
+                type inet:ipv6-prefix;
+                description
+                  "SRv6 SID.";
+                reference
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+              }
+
+              leaf multi-topology-id {
+                type uint16;
+                description
+                  "Multi Topology Identifier (MTID) of a SRv6 SID.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.2.1.";
+              }
+
+              uses bgp-ls-topo-bgp-srv6-sid-attr;
+            }
+          }
+
           container unknowns {
             description
-              "BGP-LS topology entries for unknown NLRIs -- active 
-              when the nlri-type is unknown";
+              "BGP-LS topology entries for unknown NLRIs -- active
+               when the nlri-type is unknown";
             list unknown {
               key "nlri";
               description
@@ -240,7 +745,8 @@ module ietf-bgp-lsdb {
                   "NLRI.";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
-                   Engineering Information Using BGP, Section 5.2.";
+                   Engineering Information Using BGP,
+                   Section 5.2.";
               }
 
               leaf attributes {
@@ -249,7 +755,8 @@ module ietf-bgp-lsdb {
                   "Attributes.";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
-                   Engineering Information Using BGP, Section 5.3.";
+                   Engineering Information Using BGP,
+                   Section 5.3.";
               }
             }
           }        

--- a/src/yang/ietf-bgp-lsdb.yang
+++ b/src/yang/ietf-bgp-lsdb.yang
@@ -128,7 +128,7 @@ module ietf-bgp-lsdb {
             list ospf-node {
               key "is-as-scoped area-id router-id dr-identifier as";
               description
-                "List of node types";
+                "List of OSPFv2 nodes";
 
               uses bgp-ls-ospf-node-common;
 
@@ -138,7 +138,7 @@ module ietf-bgp-lsdb {
             list ospfv3-node {
               key "is-as-scoped area-id router-id dr-identifier as";
               description
-                "List of node types";
+                "List of OSPFv3 nodes";
 
               uses bgp-ls-ospf-node-common;
 
@@ -148,7 +148,7 @@ module ietf-bgp-lsdb {
             list isis-node {
               key "system-id psn-id as";
               description
-                "List of node types";
+                "List of IS-IS nodes";
 
               leaf system-id {
                 type ietf-isis-t:system-id;
@@ -157,7 +157,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and
                    Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf psn-id {
@@ -167,7 +167,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and
                    Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf as {
@@ -178,7 +178,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and
                    Traffic Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 512.";
               }
 
               uses bgp-ls-topo-node-attr;
@@ -190,8 +190,8 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for links";
 
             list ospf-link {
-              key "is-as-scoped area-id local-as local-router-id " +
-                  "local-dr-identifier remote-as " +
+              key "area-id as local-router-id " +
+                  "local-dr-identifier " +
                   "remote-router-id remote-dr-identifier " +
                   "local-id remote-id " +
                   "local-ipv4-address remote-ipv4-address " +
@@ -205,8 +205,8 @@ module ietf-bgp-lsdb {
             }
 
             list ospfv3-link {
-              key "is-as-scoped area-id local-as local-router-id " +
-                  "local-dr-identifier remote-as " +
+              key "area-id as local-router-id " +
+                  "local-dr-identifier " +
                   "remote-router-id remote-dr-identifier " +
                   "local-id remote-id " +
                   "local-ipv4-address remote-ipv4-address " +
@@ -235,7 +235,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf local-psn-id {
@@ -245,7 +245,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf local-as {
@@ -256,7 +256,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 512.";
               }
 
               leaf remote-system-id {
@@ -266,7 +266,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf remote-psn-id {
@@ -276,7 +276,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf remote-as {
@@ -287,7 +287,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 512.";
               }
 
               leaf local-id {
@@ -297,7 +297,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 258.";
               }
 
               leaf remote-id {
@@ -307,7 +307,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 258.";
               }
 
               leaf local-ipv4-address {
@@ -317,7 +317,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 259.";
               }
 
               leaf remote-ipv4-address {
@@ -327,7 +327,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 260.";
               }
 
               leaf local-ipv6-address {
@@ -337,7 +337,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 261.";
               }
 
               leaf remote-ipv6-address {
@@ -347,7 +347,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.";
+                   Section 5.2.2. TLV 262.";
               }
 
               leaf multi-topology-id {
@@ -357,7 +357,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               uses bgp-ls-topo-igp-link-attr;
@@ -379,7 +379,7 @@ module ietf-bgp-lsdb {
                    Confederation Identifier.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 512.";
               }
 
               leaf local-router-id {
@@ -388,7 +388,7 @@ module ietf-bgp-lsdb {
                   "Local BGP Router ID.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 516.";
               }
 
               leaf remote-as {
@@ -398,7 +398,7 @@ module ietf-bgp-lsdb {
                    Confederation Identifier.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 512.";
               }
 
               leaf remote-router-id {
@@ -407,7 +407,7 @@ module ietf-bgp-lsdb {
                   "Remote BGP Router ID.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 516.";
               }
 
               leaf local-id {
@@ -416,7 +416,7 @@ module ietf-bgp-lsdb {
                   "Local Identifier of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.3.";
+                   Segments, Section 5.3. TLV 258.";
               }
 
               leaf remote-id {
@@ -425,7 +425,7 @@ module ietf-bgp-lsdb {
                   "Remote Identifier of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.3.";
+                   Segments, Section 5.3. TLV 258.";
               }
 
               leaf local-ipv4-address {
@@ -434,7 +434,7 @@ module ietf-bgp-lsdb {
                   "Local IPv4 address of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.2.";
+                   Segments, Section 5.2. TLV 259.";
               }
 
               leaf remote-ipv4-address {
@@ -443,7 +443,7 @@ module ietf-bgp-lsdb {
                   "Remote IPv4 address of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.2.";
+                   Segments, Section 5.2. TLV 260.";
               }
 
               leaf local-ipv6-address {
@@ -452,7 +452,7 @@ module ietf-bgp-lsdb {
                   "Local IPv6 address of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.2.";
+                   Segments, Section 5.2. TLV 261.";
               }
 
               leaf remote-ipv6-address {
@@ -461,7 +461,7 @@ module ietf-bgp-lsdb {
                   "Remote IPv6 address of a link.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 5.2.";
+                   Segments, Section 5.2. TLV 262.";
               }
 
               leaf multi-topology-id {
@@ -471,7 +471,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               uses bgp-ls-topo-bgp-link-attr;
@@ -483,7 +483,8 @@ module ietf-bgp-lsdb {
               "BGP-LS topology entries for prefixes";
 
             list ospf-prefix {
-              key "is-as-scoped as router-id dr-identifier " +
+              key "is-as-scoped area-id as " +
+                  "router-id dr-identifier " +
                   "multi-topology-id route-type prefix";
               description
                 "List of OSPFv2 prefix types";
@@ -493,7 +494,8 @@ module ietf-bgp-lsdb {
             }
 
             list ospfv3-prefix {
-              key "is-as-scoped as router-id dr-identifier " +
+              key "is-as-scoped area-id as " +
+                  "router-id dr-identifier " +
                   "multi-topology-id route-type prefix";
               description
                 "List of OSPFv3 prefix types";
@@ -514,7 +516,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf psn-id {
@@ -524,7 +526,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf as {
@@ -535,7 +537,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.";
+                   Section 5.2. TLV 512.";
               }
 
               leaf multi-topology-id {
@@ -545,7 +547,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               leaf prefix {
@@ -556,7 +558,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.3.2.";
+                   Section 5.2.3.2. TLV 265.";
               }
             }
 
@@ -567,10 +569,32 @@ module ietf-bgp-lsdb {
             description
               "BGP-LS topology entries for SRv6 SIDs";
 
-            list ospf-srv6-sid {
-              key "router-id dr-identifier as sid multi-topology-id";
+            list ospfv3-srv6-sid {
+              key "is-as-scoped area-id router-id " +
+                  "dr-identifier as sid multi-topology-id";
               description
                 "List of OSPF SRv6 SID types";
+
+              leaf is-as-scoped {
+                type boolean;
+                description
+                  "Flag indicating whether the OSPF link-state
+                   identifier is AS scoped.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1.";
+              }
+
+              leaf area-id {
+                type inet:ipv4-address;
+                description
+                  "OSPF area identifier.";
+                reference
+                  "RFC 9552: Distribution of Link-State and Traffic
+                   Engineering Information Using BGP,
+                   Section 5.2.1. TLV 514.";
+              }
 
               leaf router-id {
                 type ietf-rt-t:router-id;
@@ -579,20 +603,17 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf dr-identifier {
-                type union {
-                  type inet:ipv4-address;
-                  type uint32;
-                }
+                type uint32;
                 description
                   "Designated Router (DR) Identifier.";
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf as {
@@ -603,7 +624,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.";
+                   Section 5.2. TLV 512.";
               }
 
               leaf sid {
@@ -611,7 +632,8 @@ module ietf-bgp-lsdb {
                 description
                   "SRv6 SID.";
                 reference
-                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.
+                   TLV 518.";
               }
 
               leaf multi-topology-id {
@@ -621,7 +643,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               uses bgp-ls-topo-srv6-sid-attr;
@@ -639,7 +661,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf psn-id {
@@ -649,7 +671,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.1.";
+                   Section 5.2.1. TLV 515.";
               }
 
               leaf as {
@@ -660,7 +682,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.";
+                   Section 5.2. TLV 512.";
               }
 
               leaf sid {
@@ -668,7 +690,8 @@ module ietf-bgp-lsdb {
                 description
                   "SRv6 SID.";
                 reference
-                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.
+                   TLV 518.";
               }
 
               leaf multi-topology-id {
@@ -678,7 +701,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               uses bgp-ls-topo-srv6-sid-attr;
@@ -695,7 +718,7 @@ module ietf-bgp-lsdb {
                   "BGP Router ID.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 516.";
               }
 
               leaf as {
@@ -705,7 +728,7 @@ module ietf-bgp-lsdb {
                    Confederation Identifier.";
                 reference
                   "RFC 9086: BGP-LS Extensions for BGP Peering
-                   Segments, Section 4.2.";
+                   Segments, Section 4.2. TLV 517.";
               }
 
               leaf sid {
@@ -713,7 +736,8 @@ module ietf-bgp-lsdb {
                 description
                   "SRv6 SID.";
                 reference
-                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.";
+                  "RFC 9514: BGP-LS SRv6 Extensions, Section 6.1.
+                   TLV 518.";
               }
 
               leaf multi-topology-id {
@@ -723,7 +747,7 @@ module ietf-bgp-lsdb {
                 reference
                   "RFC 9552: Distribution of Link-State and Traffic
                    Engineering Information Using BGP,
-                   Section 5.2.2.1.";
+                   Section 5.2.2.1. TLV 263.";
               }
 
               uses bgp-ls-topo-bgp-srv6-sid-attr;


### PR DESCRIPTION
Added support for Link, Prefix and SRv6 SID NLRIs and their attributes. Covers attributes of IGP and BGP EPE use cases.